### PR TITLE
删除 babel-eslint & 升级 mip2 到 1.0.10

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "parser": "vue-eslint-parser",
   "parserOptions": {
-      "parser": "babel-eslint",
+      "ecmaVersion": 8,
       "sourceType": "module",
       "allowImportExportEverywhere": false
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "mip-sandbox": "^1.0.10"
   },
   "devDependencies": {
-    "babel-eslint": "^8.2.3",
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.12.0",
@@ -43,6 +42,6 @@
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "husky": "^1.0.0-rc.8",
-    "mip2": "^1.0.4"
+    "mip2": "^1.0.10"
   }
 }


### PR DESCRIPTION
1. babel-eslint 有 bug，在某些复杂模板字符串校验时会堆栈溢出，而且直接使用 eslint 配置 parserOptions 可以达到同样的功能，因此需要删掉；
2. mip2（mip-cli）在 1.0.10 版本新增子组件注册 custom element 功能，需要升级版本依赖