### PR TITLE
小说目录页 fix: 修复多次点击目录章节数再返回直接跳转结果页（增加replace属性）

### DIFF
--- a/components/mip-shell-xiaoshuo/feature/catalog.js
+++ b/components/mip-shell-xiaoshuo/feature/catalog.js
@@ -70,7 +70,7 @@ class Catalog {
       renderCatalog = catalogs => catalogs.map(catalog => `
         <div class="catalog-page">
           <a class="mip-catalog-btn catalog-page-content" 
-          mip-catalog-btn mip-link data-button-name="${catalog.name}" href="${catalog.link}">
+          mip-catalog-btn mip-link data-button-name="${catalog.name}" href="${catalog.link}" replace>
           ${catalog.name}
           </a>
         </div>`).join('\n')


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （小说目录页 fix: 修复多次点击目录章节数再返回直接跳转结果页（章节增加replace属性））

**2、影响范围** （修复多次点击目录章节数再返回直接跳转结果页）

**3、自测 checklist** 小说目录页 fix: 修复多次点击目录章节数再返回直接跳转结果页（章节增加replace属性）

**4、需要覆盖的场景和case**
- [是 ] 是否覆盖了sf打开mip页
- [ 是] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [ 是] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



