### PR TITLE
小说阅读器  修复目录页点击章节后边空白处不跳转

### DIFF
--- a/components/mip-shell-xiaoshuo/example/mipx-xiaoshuo-2-1.html
+++ b/components/mip-shell-xiaoshuo/example/mipx-xiaoshuo-2-1.html
@@ -390,10 +390,6 @@
                             "next": "下一页"
                         }
                     },
-                    "book": {
-                        "title": "将夜",
-                        "chapterNumber": "已完结&nbsp;&nbsp;共1347章"
-                    },
                     "catalog": [
                         {
                             "name": "第1章 灵魂重生",

--- a/components/mip-shell-xiaoshuo/feature/catalog.js
+++ b/components/mip-shell-xiaoshuo/feature/catalog.js
@@ -14,7 +14,7 @@ class Catalog {
     this.propagationStopped = this._stopPropagation()
   }
 
-  // 根据配置渲染目录侧边栏到 mip-sidebar组件中
+  // 根据配置渲染目录侧边栏到  mip-sidebar组件中
   // 支持从页面直接获取目录，异步获取目录
   _renderCatalog (catalogs, book) {
     let renderCatalog
@@ -307,12 +307,12 @@ class Catalog {
     for (let i = 0; i < catalog.length; i++) {
       catalog[i].innerHTML = catalog[i].innerHTML
     }
-    document.querySelector('body').classList.add('bodyForbid')
+    document.body.classList.add('body-forbid')
     // }, 400)
   }
   // 隐藏侧边目录
   hide () {
-    document.querySelector('body').classList.remove('bodyForbid')
+    document.body.classList.remove('body-forbid')
     this.$catalogSidebar.classList.remove('show')
   }
   // 禁止冒泡，防止目录滚动到底后，触发外层小说页面滚动

--- a/components/mip-shell-xiaoshuo/feature/catalog.js
+++ b/components/mip-shell-xiaoshuo/feature/catalog.js
@@ -307,11 +307,12 @@ class Catalog {
     for (let i = 0; i < catalog.length; i++) {
       catalog[i].innerHTML = catalog[i].innerHTML
     }
-
+    document.querySelector('body').classList.add('bodyForbid')
     // }, 400)
   }
   // 隐藏侧边目录
   hide () {
+    document.querySelector('body').classList.remove('bodyForbid')
     this.$catalogSidebar.classList.remove('show')
   }
   // 禁止冒泡，防止目录滚动到底后，触发外层小说页面滚动

--- a/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
+++ b/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
@@ -186,6 +186,7 @@ mip-fixed.mip-shell-catalog-wrapper {
   }
 
   .mip-catalog-btn {
+    display: block;
     top:0;   
     padding: 15px 16px;
   }
@@ -285,7 +286,9 @@ mip-fixed.mip-shell-catalog-wrapper {
 
 
 }
-
+.bodyForbid {
+  overflow: hidden!important;
+}
 
 #catalog-scroll-btn {
   width: 1.54em;

--- a/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
+++ b/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
@@ -187,7 +187,7 @@ mip-fixed.mip-shell-catalog-wrapper {
 
   .mip-catalog-btn {
     display: block;
-    top:0;   
+    top: 0;
     padding: 15px 16px;
   }
 
@@ -286,7 +286,7 @@ mip-fixed.mip-shell-catalog-wrapper {
 
 
 }
-.bodyForbid {
+.body-forbid {
   overflow: hidden!important;
 }
 


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#201 
**1、升级点** （
小说阅读器  修复目录页点击章节后边空白处不跳转
）

**2、影响范围** （无）

**3、自测 checklist**
小说阅读器  修复目录页点击章节后边空白处不跳转

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [x] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百



