### PR TITLE
fix travis npm install timeout issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 os:
   - linux
 install:
-  - npm install
+  - travis_retry npm install
 script:
   - npm run lint
 


### PR DESCRIPTION
**1、升级点** （清晰准确的描述升级的功能点）

travis 构建 npm install 安装依赖偶尔会超时，增加 retry 方法

**2、影响范围** （描述该需求上线会影响什么功能）

对组件无影响，免测





