### PR TITLE
【申请免测】 修复mip-toast在ios的sf下不居中问题

### DIFF
--- a/components/mip-form/mip-form.less
+++ b/components/mip-form/mip-form.less
@@ -72,4 +72,3 @@ mip-form {
     display: none;
   }
 }
-

--- a/components/mip-inservice-pay/mip-inservice-pay.vue
+++ b/components/mip-inservice-pay/mip-inservice-pay.vue
@@ -858,5 +858,4 @@ export default {
     }
   }
 }
-
 </style>

--- a/components/mip-novel-video/mip-novel-video.vue
+++ b/components/mip-novel-video/mip-novel-video.vue
@@ -573,5 +573,4 @@ mip-novel-video {
     height: 100%;
   }
 }
-
 </style>

--- a/components/mip-toast/README.md
+++ b/components/mip-toast/README.md
@@ -17,28 +17,20 @@
 1、弹出框 只弹出文字（不传 info-icon-src）
 
 ```html
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
-<mip-test on="show:demo.show"></mip-test>
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
-
+<!-- <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>    测试组件，模拟接收和抛出事件 -->
 <mip-toast
   id= "demo"
-  info-text="默认提示框"
+  info-text="最多七个中文字"
   station = "top"
   auto-close = "true"
 >
 </mip-toast>
-  <!--  测试组件，模拟接收和抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
-  <!--  测试组件，模拟接收和抛出事件 -->
-```
 
+```
 2、弹出框 弹出带图和文字
 
 ```html
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
-<mip-test on="show:demo.show"></mip-test>
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+<!-- <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>    测试组件，模拟接收和抛出事件 -->
 <mip-toast
   id= "demo"
   info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
@@ -47,9 +39,7 @@
   auto-close = "true"
 >
 </mip-toast>
-<!-- 测试组件，模拟接收和抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
-<!-- 测试组件，模拟接收和抛出事件 -->
+
 ```
 
 ## 属性

--- a/components/mip-toast/README.md
+++ b/components/mip-toast/README.md
@@ -17,20 +17,28 @@
 1、弹出框 只弹出文字（不传 info-icon-src）
 
 ```html
-<!-- <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>    测试组件，模拟接收和抛出事件 -->
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+<mip-test on="show:demo.show"></mip-test>
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+
 <mip-toast
   id= "demo"
-  info-text="最多七个中文字"
+  info-text="默认提示框"
   station = "top"
   auto-close = "true"
 >
 </mip-toast>
-
+  <!--  测试组件，模拟接收和抛出事件 -->
+  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
+  <!-- 测试组件，模拟接收和抛出事件 -->
 ```
+
 2、弹出框 弹出带图和文字
 
 ```html
-<!-- <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>    测试组件，模拟接收和抛出事件 -->
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+<mip-test on="show:demo.show"></mip-test>
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
 <mip-toast
   id= "demo"
   info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
@@ -39,7 +47,9 @@
   auto-close = "true"
 >
 </mip-toast>
-
+<!-- 测试组件，模拟接收和抛出事件 -->
+  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
+<!-- 测试组件，模拟接收和抛出事件 -->
 ```
 
 ## 属性

--- a/components/mip-toast/README.md
+++ b/components/mip-toast/README.md
@@ -17,20 +17,28 @@
 1、弹出框 只弹出文字（不传 info-icon-src）
 
 ```html
-<!-- <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>    测试组件，模拟接收和抛出事件 -->
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+<mip-test on="show:demo.show"></mip-test>
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+
 <mip-toast
   id= "demo"
-  info-text="最多七个中文字"
+  info-text="默认提示框"
   station = "top"
   auto-close = "true"
 >
 </mip-toast>
-
+  <!--  测试组件，模拟接收和抛出事件 -->
+  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
+  <!--  测试组件，模拟接收和抛出事件 -->
 ```
+
 2、弹出框 弹出带图和文字
 
 ```html
-<!-- <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>    测试组件，模拟接收和抛出事件 -->
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+<mip-test on="show:demo.show"></mip-test>
+<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
 <mip-toast
   id= "demo"
   info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
@@ -39,7 +47,9 @@
   auto-close = "true"
 >
 </mip-toast>
-
+<!-- 测试组件，模拟接收和抛出事件 -->
+  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
+<!-- 测试组件，模拟接收和抛出事件 -->
 ```
 
 ## 属性

--- a/components/mip-toast/mip-toast.vue
+++ b/components/mip-toast/mip-toast.vue
@@ -70,7 +70,7 @@ export default {
   },
   methods: {
     init () {
-      if (typeof this.closeTime === 'number' && !!this.closeTime) {
+      if (typeof this.closeTime === 'number' && !!this.closeTime && this.closeTime !== 2500) {
         this.showTime = this.closeTime * 1000
       }
       if (!this.infoIconSrc) {
@@ -120,14 +120,17 @@ export default {
 
 .center {
   top: 33%;
+  text-align: center;
 }
 
 .top {
   top: 10%;
+  text-align: center;
 }
 
 .bottom {
   top: 70%;
+  text-align: center;
 }
 
 .icon {

--- a/components/mip-toast/mip-toast.vue
+++ b/components/mip-toast/mip-toast.vue
@@ -70,7 +70,7 @@ export default {
   },
   methods: {
     init () {
-      if (typeof this.closeTime === 'number' && !!this.closeTime && this.closeTime !== 2500) {
+      if (typeof this.closeTime === 'number' && !!this.closeTime) {
         this.showTime = this.closeTime * 1000
       }
       if (!this.infoIconSrc) {
@@ -120,17 +120,14 @@ export default {
 
 .center {
   top: 33%;
-  text-align: center;
 }
 
 .top {
   top: 10%;
-  text-align: center;
 }
 
 .bottom {
   top: 70%;
-  text-align: center;
 }
 
 .icon {


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

在sf的ios下，支持提示框居中

**2、影响范围** （描述该需求上线会影响什么功能）
无
**3、自测 checklist**

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [x] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百



