### PR TITLE
feat: 完成 mip-mathml 组件

### DIFF
--- a/components/mip-mathml/README.md
+++ b/components/mip-mathml/README.md
@@ -55,3 +55,12 @@
 单位：无   
 默认值：false  
 使用限制：无
+
+### mathjaxConfig
+
+说明: mathjax 配置参数，参考 http://docs.mathjax.org/en/latest/config-files.html#common-configurations
+必填：否
+格式：字符串     
+单位：无   
+默认值：TeX-MML-AM_CHTML （包含最全的数学公式支持）  
+使用限制：无

--- a/components/mip-mathml/README.md
+++ b/components/mip-mathml/README.md
@@ -1,0 +1,57 @@
+# `mip-mathml`
+
+标题|内容
+----|----
+类型|
+支持布局|
+所需脚本| [https://c.mipcdn.com/static/v2/mip-mathml/mip-mathml.js](https://c.mipcdn.com/static/v2/mip-mathml/mip-mathml.js)
+
+## 说明
+
+这个扩展组件会创建一个 iframe 并且渲染 MathML 公式
+
+## 示例
+
+示例：二次公式
+
+```html
+<mip-mathml layout="container" formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"></mip-mathml>
+```
+
+示例：柯西积分公式
+
+```html
+<mip-mathml layout="container" formula="\[f(a) = \frac{1}{2\pi i} \oint\frac{f(z)}{z-a}dz\]"></mip-mathml>
+```
+
+示例：余弦的双角公式
+
+```html
+<mip-mathml layout="container" formula="\[ \cos(θ+φ)=\cos(θ)\cos(φ)−\sin(θ)\sin(φ) \]"></mip-mathml>
+```
+
+示例：内敛公式
+
+```html
+这个例子  <mip-mathml layout="container" inline formula="\[ \cos(θ+φ) \]"></mip-mathml> 让这个公式内敛在文本当中
+```
+
+## 属性
+
+### formula
+
+说明：指定要渲染的公式 
+必填：是    
+格式：字符串      
+单位：无   
+默认值：无  
+使用限制：无
+
+### inline
+
+说明：这个公式需要内敛
+必填：否
+格式：布尔      
+单位：无   
+默认值：false  
+使用限制：无

--- a/components/mip-mathml/README.md
+++ b/components/mip-mathml/README.md
@@ -3,7 +3,7 @@
 标题|内容
 ----|----
 类型|
-支持布局|
+支持布局| responsive, fixed-height, fill, container, fixed
 所需脚本| [https://c.mipcdn.com/static/v2/mip-mathml/mip-mathml.js](https://c.mipcdn.com/static/v2/mip-mathml/mip-mathml.js)
 
 ## 说明

--- a/components/mip-mathml/example/mip-mathml.html
+++ b/components/mip-mathml/example/mip-mathml.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html mip>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>MIP page</title>
+    <link rel="canonical" href="对应的原页面地址">
+    <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
+    <style mip-custom>
+    </style>
+  </head>
+  <body>
+    <h2>二次公式</h2>
+    <mip-mathml layout="container" formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"></mip-mathml>
+    <h2>柯西积分公式</h2>
+    <mip-mathml layout="container" formula="\[f(a) = \frac{1}{2\pi i} \oint\frac{f(z)}{z-a}dz\]"></mip-mathml>
+    <h2>余弦的双角公式</h2>
+    <mip-mathml layout="container" formula="\[ \cos(θ+φ)=\cos(θ)\cos(φ)−\sin(θ)\sin(φ) \]"></mip-mathml>
+    <h2>内敛公式</h2>
+    这个例子让这个公式内敛在文本当中 <mip-mathml layout="container" inline formula="\[ \cos(θ+φ) \]"></mip-mathml> 这个需要额外的 css 去设置 
+    <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
+    <script src="/mip-mathml/mip-mathml.js"></script>
+  </body>
+</html>

--- a/components/mip-mathml/mip-mathml.vue
+++ b/components/mip-mathml/mip-mathml.vue
@@ -28,8 +28,6 @@
 }
 </style>
 <script>
-const MATHML = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML'
-
 export default {
   props: {
     formula: {
@@ -39,10 +37,15 @@ export default {
     inline: {
       type: Boolean,
       default: false
+    },
+    mathjaxConfig: {
+      type: String,
+      default: 'TeX-MML-AM_CHTML'
     }
   },
   data () {
     return {
+      MATHJAX_CDN: `https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=${this.mathjaxConfig}`,
       iframeID: Date.now(),
       iframeBody: null,
       height: 0,
@@ -75,7 +78,7 @@ export default {
     getIframeBody () {
       /* eslint-disable no-useless-escape */
       let body = `
-      <script type="text/javascript" src="${MATHML}"><\/script>
+      <script type="text/javascript" src="${this.MATHJAX_CDN}"><\/script>
       <div>${this.formula}</div>
       <script>
       MathJax.Hub.Queue(function() {

--- a/components/mip-mathml/mip-mathml.vue
+++ b/components/mip-mathml/mip-mathml.vue
@@ -45,7 +45,7 @@ export default {
   },
   data () {
     return {
-      MATHJAX_CDN: `https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=${this.mathjaxConfig}`,
+      MATHJAX_CDN: `https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=${this.mathjaxConfig}`,
       iframeID: `${Date.now()}_${Math.ceil(Math.random() * 100000)}`,
       iframeBody: null,
       height: 0,

--- a/components/mip-mathml/mip-mathml.vue
+++ b/components/mip-mathml/mip-mathml.vue
@@ -53,10 +53,10 @@ export default {
     }
   },
   created () {
-    window.addEventListener('message', this.messageHandler, false)
+    window.addEventListener('message', this.messageHandler)
   },
   beforeDestroy () {
-    window.removeEventListener('message', this.messageHandler, false)
+    window.removeEventListener('message', this.messageHandler)
   },
   mounted () {
     if (this.inline) {

--- a/components/mip-mathml/mip-mathml.vue
+++ b/components/mip-mathml/mip-mathml.vue
@@ -88,13 +88,13 @@ export default {
       <script>
       MathJax.Hub.Queue(function() {
         var rendered = document.getElementById('MathJax-Element-1-Frame')
-        var display = document.getElementsByClassName('MJXc-display');
+        var display = document.getElementsByClassName('MJXc-display')
         // 移除 mathjax 和 body 的默认边距
         if (display[0]) {
-          document.body.setAttribute('style','margin:0');
-          display[0].setAttribute('style','margin-top:0;margin-bottom:0');
+          document.body.setAttribute('style','margin:0')
+          display[0].setAttribute('style','margin-top:0;margin-bottom:0')
           window.parent.postMessage({
-            iframeID: ${this.iframeID},
+            iframeID: '${this.iframeID}',
             width: rendered.offsetWidth,
             height: rendered.offsetHeight
           }, '*')


### PR DESCRIPTION
**1、升级点** 

mip-mathml 组件，使用 mathml 语言编写数学公式

为了避免 mathjax.js 对主页面的影响，并且需要对加载速度有要求，使用 iframe 渲染 Mathml，大体思路：

1. 创建 iframe，cdn 加载 mathml 核心库 mathjax
2. 把字符渲染成数学公式
3. 渲染完后设置 iframe 宽高

**2、影响范围** 

无

**3、自测 checklist**

-  [x] 常见数学公式
-  [x] 内敛方式的数学公式

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百


![wechatimg49](https://user-images.githubusercontent.com/6399899/46656645-1da17200-cbe1-11e8-9cb7-1e89bb4d09d7.jpeg)



