### PR TITLE
【免测】写死 stylelint 版本为 9.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "glob": "^7.1.2",
     "husky": "^1.0.0-rc.8",
     "mip2": "^1.1.3",
-    "stylelint": "^9.4.0",
+    "stylelint": "9.6.0",
     "stylelint-config-standard": "^18.2.0"
   }
 }


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#312

**1、升级点** （清晰准确的描述升级的功能点）
写死 stylelint 版本为 9.6.0 直到最新版修复问题

**2、影响范围** （描述该需求上线会影响什么功能）
mip2-extensions 的代码提交和 PR 检测

**3、自测 checklist**
- [x] 写死 stylelint 版本后校验通过




