### PR TITLE
Fix:小说common异常监控日志，线上目录页不应该异常打点

### DIFF
--- a/components/mip-shell-xiaoshuo/feature/catalog.js
+++ b/components/mip-shell-xiaoshuo/feature/catalog.js
@@ -287,11 +287,19 @@ class Catalog {
     let catalog = $catalogContent.querySelectorAll('div')
     let reverseName = $contentTop.querySelector('.reverse-name')
     let temp = []
-    for (let i = 0, len = catalog.length; i < len; i++) {
+    let length = catalog.length
+    for (let i = 0; i < length; i++) {
       temp[i] = catalog[i].outerHTML
     }
     reverse.addEventListener('click', () => {
-      $catalogContent.innerHTML = temp.reverse().join('')
+      for (let left = 0; left < length / 2; left++) {
+        let right = length - 1 - left
+        let temporary = temp[left]
+        temporary = temp[left]
+        temp[left] = temp[right]
+        temp[right] = temporary
+      }
+      $catalogContent.innerHTML = temp.join('')
       reverseName.innerHTML = reverseName.innerHTML === ' 正序' ? ' 倒序' : ' 正序'
       let catalog = $catalogContent.querySelectorAll('div')
       let $catWrapper = document.querySelector('.novel-catalog-content-wrapper')

--- a/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
+++ b/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
@@ -39,6 +39,10 @@
   transform: translateY(100%);
   font-size: 14px;
 
+  ul {
+    list-style: none;
+  }
+
   .button p {
     font-size: 16px;
   }
@@ -74,7 +78,7 @@
 
       i p {
         margin-top: 6px;
-        font-size: 12px;
+        font-size: 12px !important;
         margin-bottom: 20px;
       }
 

--- a/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
+++ b/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.less
@@ -295,6 +295,9 @@ mip-fixed.mip-shell-catalog-wrapper {
   .catalog-page-content {
     line-height: 16px;
     font-size: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .width-50 {


### PR DESCRIPTION
测试时候没有测试线上的目录页，导致从目录页进入common异常打点，
原因：common异常打点是common请求异常发送异常日志，而common请求是在mip-custom组件里做判断，而在目录页时mip-custom组件并未加载，导致判断发送异常日志条件为false

**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



