### PR TITLE
 fix: 修复线上目录页不应监控common异常日志

### DIFF
--- a/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.js
+++ b/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.js
@@ -135,9 +135,11 @@ export default class MipShellXiaoshuo extends MIP.builtinComponents.MipShell {
     // 绑定小说每个页面的监听事件，如翻页，到了每章最后一页
 
     xiaoshuoEvents.bindAll()
-    // 发送webb性能日志，common 5s 请求失败，发送common 异常日志
-    sendWebbLogCommon()
 
+    // 发送webb性能日志 , 请求common时 ,common 5s 请求失败，发送common异常日志
+    if (document.querySelector('mip-custom')) {
+      sendWebbLogCommon()
+    }
     // 当页面翻页后，需要修改footer中【上一页】【下一页】链接
     if (!isRootPage) {
       let jsonld = getJsonld(window)


### PR DESCRIPTION
bug  线上目录页监控发送了common异常日志
情况：章节目录监控了common异常日志，但目录页common未请求，
原因：测试时未测目录章节部分，而目录页加载了小说阅读器组件，小说阅读器组件发送common异常
解决：有common请求时才监控异常，判断是否有mip-custom组件再 监控异常

**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



