### PR TITLE
修复: 构建时的示例预览页不支持子目录的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "husky": "^1.0.0-rc.8",
-    "mip2": "^1.1.3",
+    "mip2": "^1.4.3",
     "stylelint": "9.6.0",
     "stylelint-config-standard": "^18.2.0"
   }

--- a/tools/site.js
+++ b/tools/site.js
@@ -12,10 +12,10 @@ const dist = path.resolve(__dirname, '../dist')
 const examplesPath = path.resolve(dist, 'examples')
 
 // copy example files from /components dir to dist/examples
-glob.sync('components/mip-*/example/*.*', {realpath: true})
-  .forEach(file => {
-    let compName = file.match(/components\/(mip-.+)\/example/)[1]
-    fs.copySync(file, path.join(dist, 'examples', compName, path.basename(file)))
+glob.sync('components/mip-*', {realpath: true})
+  .forEach(cPath => {
+    let compName = cPath.match(/components\/(mip-.+)/)[1]
+    fs.copySync(path.join(cPath, 'example'), path.join(dist, 'examples', compName))
   })
 
 const components = fs.readdirSync(examplesPath).map(comp => {


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

组件的 example 目录下如果包含子目录，构建生成预览页面时，不能递归拷贝，会出现预览失败的情况。

**2、影响范围** （描述该需求上线会影响什么功能）

对组件无影响

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



