### PR TITLE
fix：修复 mip-nav-slidedown 下拉列表的按钮无法点击的 bug

### DIFF
--- a/components/mip-nav-slidedown/README.md
+++ b/components/mip-nav-slidedown/README.md
@@ -26,7 +26,7 @@
           <a href="//www.mipengine.org/timeline.html">动态</a>
         </li>
         <li>
-          <a href="http://www.cnblogs.com/mipengine/">博客</>
+          <a href="http://www.cnblogs.com/mipengine/">博客</a>
         </li>
         <li class="navbar-wise-close">
           <span id="navbar-wise-close-btn"></span>
@@ -72,7 +72,7 @@
 直接添加`<ul>`可以展现二级菜单效果。
 ```html
 <div class="mip-nav-wrapper">
-  <mip-nav-slidedown 
+  <mip-nav-slidedown
     data-id="bs-navbar"
     class="mip-element-sidebar container"
     data-showbrand="1"
@@ -114,27 +114,27 @@
 
 ## 属性
 
-### data-id  
-说明：内部菜单 `id`  
-必选项：是  
-类型：字符串  
+### data-id
+说明：内部菜单 `id`
+必选项：是
+类型：字符串
 
-### data-showbrand  
-说明：是否需要左上角显示可点击区域  
-必选项：否  
-类型：数字  
-取值：0（不显示），1（显示）  
+### data-showbrand
+说明：是否需要左上角显示可点击区域
+必选项：否
+类型：数字
+取值：0（不显示），1（显示）
 默认值：1
 
-### data-brandname  
-说明：左上角显示可点击区域文字，仅在 `data-showbrand=1` 时显示  
-必选项：否  
-类型：字符串，如 "MIP官网"  
+### data-brandname
+说明：左上角显示可点击区域文字，仅在 `data-showbrand=1` 时显示
+必选项：否
+类型：字符串，如 "MIP官网"
 
-### data-brandhref  
-说明：左上角图标跳转链接，在 `data-showbrand` 为 1 时有效  
-必选项：否  
-类型：URL  
+### data-brandhref
+说明：左上角图标跳转链接，在 `data-showbrand` 为 1 时有效
+必选项：否
+类型：URL
 默认：'/'
 
 ## 注意事项

--- a/components/mip-nav-slidedown/mip-nav-slidedown.js
+++ b/components/mip-nav-slidedown/mip-nav-slidedown.js
@@ -48,7 +48,7 @@ export default class MipNavSlidedown extends CustomElement {
   bindEvents () {
     this.element.querySelector('.navbar-header .navbar-toggle').addEventListener('click', this.navClickHandler, false)
     let $closeBtn = this.element.querySelector('#navbar-wise-close-btn')
-    if ($closeBtn.length > 0) {
+    if ($closeBtn) {
       this.addHoverClass($closeBtn)
       $closeBtn.addEventListener('click', this.navClickHandler, false)
       $closeBtn.addEventListener('touchend', this.navClickHandler, false)


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#402 
**1、升级点** （清晰准确的描述升级的功能点）
修复 mip-nav-slidedown 下拉列表的按钮无法点击的 bug

**2、影响范围** （描述该需求上线会影响什么功能）
线上 v2 的 mip-nav-sildedown 组件

**3、自测 checklist**
1. 组件 example 点击关闭按钮能正常收起下来菜单

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



