### PR TITLE
fix: Fix bugs in mip-stats-baidu

### DIFF
--- a/components/mip-stats-baidu/mip-stats-baidu.js
+++ b/components/mip-stats-baidu/mip-stats-baidu.js
@@ -13,6 +13,7 @@ export default class MipStatsBaidu extends CustomElement {
 
     // 获取参数
     this.config = this.getConfig()
+    this.created()
   }
 
   // 提前渲染
@@ -20,7 +21,7 @@ export default class MipStatsBaidu extends CustomElement {
     return true
   }
 
-  connectedCallback () {
+  created () {
     let { element, config } = this
 
     if (!config) {
@@ -91,11 +92,27 @@ export default class MipStatsBaidu extends CustomElement {
     }
   }
 
-  // 绑定事件追踪
+  /**
+   * 绑定事件追踪
+   */
   bindEle () {
-    // 获取所有需要触发的dom
-    let tagBox = document.querySelectorAll('*[data-stats-baidu-obj]')
+    const now = Date.now()
+    const intervalTimer = setInterval(() => {
+      // 获取所有需要触发的dom
+      this.bindEleHandler(document.querySelectorAll('*[data-stats-baidu-obj]'))
+      // 由于存在异步渲染
+      if (Date.now() - now >= 8000) {
+        clearInterval(intervalTimer)
+      }
+    }, 100)
+  }
 
+  /**
+   * 处理点击统计的 dom 列表
+   *
+   * @param {Array<HTMLElement>} tagBox 需要记录点击统计的 dom 元素列表
+   */
+  bindEleHandler (tagBox) {
     for (let node of tagBox.values()) {
       let statusData = node.getAttribute('data-stats-baidu-obj')
 


### PR DESCRIPTION
https://github.com/mipengine/mip2-extensions/issues/404

**1、升级点**
 - mip1 里原本在 `createdCallback` 的逻辑挪到 `constructor`，而不是 `connectedCallback`
 - 补上异步绑定逻辑

**2、影响范围** 
 - 使用此百度统计组件的站点

**3、自测 checklist**
 - bug 不明确，目前只是同步 mip1 的逻辑，需要回归使用此组件的站点是否无报错

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



