### PR TITLE
fix:修复IOS上折叠组件下面文字透出的问题

### DIFF
--- a/components/mip-showmore/mip-showmore.less
+++ b/components/mip-showmore/mip-showmore.less
@@ -5,7 +5,6 @@
 mip-showmore {
   visibility: hidden;
   overflow: hidden;
-  transform: translateZ(0);
 
   .mip-showmore {
     &-originalhtml,


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
 [462](https://github.com/mipengine/mip2-extensions/issues/462)
**1、升级点** （清晰准确的描述升级的功能点）
IOS 手百合作页折叠组件文字透出
**2、影响范围** （描述该需求上线会影响什么功能）
IOS 手百医疗合作页
**3、自测 checklist**
不同资源方的合作页折叠效果
不同手机和浏览器合作页折叠效果

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [x] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百



