### PR TITLE
fix：mip-vd-tabs 个别浏览器展现有误

### DIFF
--- a/components/mip-vd-tabs/mip-vd-tabs.js
+++ b/components/mip-vd-tabs/mip-vd-tabs.js
@@ -357,7 +357,7 @@ export default class MIPVdTabs extends CustomElement {
         .find('.mip-vd-tabs-nav-layer')
         .css({'position': 'fixed', 'border-top': '1px solid #ccc', 'top': '0'})
       tab.toggle.css({
-        '-webkit-transform': 'scaleY(1)',
+        '-webkit-transform': 'scaleY(-1)',
         'transform': 'scaleY(-1)'
       })
       tab.toggleState = 1

--- a/components/mip-vd-tabs/tab.js
+++ b/components/mip-vd-tabs/tab.js
@@ -136,7 +136,7 @@ export default class Tab {
       $navLayer.append($navLayerUl)
       this.view.after($navLayer.show())
       this.toggle.css({
-        '-webkit-transform': 'scaleY(1)',
+        '-webkit-transform': 'scaleY(-1)',
         'transform': 'scaleY(-1)'
       })
       this.toggleState = 1


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

Android 4.4 小米原生浏览器，剧集展开时箭头样式不正确。
原因：该浏览器不支持 transform: scaleY(-1) 属性，组件原来的逻辑使用 js 设置样式的时候，书写有误。

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



