### PR TITLE
修复 accordion MIP 组件嵌套 & section 嵌套 bug

### DIFF
--- a/components/mip-accordion/mip-accordion.js
+++ b/components/mip-accordion/mip-accordion.js
@@ -171,6 +171,7 @@ function getSibling (el) {
 /**
  * 获取组件 slot 下面的所有 <section>，并且过滤掉嵌套 MIP 组件下面的 section，以免 MIP 组件嵌套造成相互影响
  *
+ * @param {HTMLElement} element 组件根节点
  * @return {Array.<HTMLElement>} selection 列表
  */
 function getSections (element) {

--- a/components/mip-accordion/mip-accordion.js
+++ b/components/mip-accordion/mip-accordion.js
@@ -168,6 +168,31 @@ function getSibling (el) {
   return el
 }
 
+/**
+ * 获取组件 slot 下面的所有 <section>，并且过滤掉嵌套 MIP 组件下面的 section，以免 MIP 组件嵌套造成相互影响
+ *
+ * @return {Array.<HTMLElement>} selection 列表
+ */
+function getSections (element) {
+  const sections = element.querySelectorAll('section')
+  let validSections = []
+  for (let i = 0; i < sections.length; i++) {
+    let section = sections[i]
+
+    let parent = section.parentNode
+    while (parent) {
+      if (parent.tagName.indexOf('MIP-') === 0) {
+        if (parent === element) {
+          validSections.push(section)
+        }
+        break
+      }
+      parent = parent.parentNode
+    }
+  }
+  return validSections
+}
+
 export default class MIPAccordion extends CustomElement {
   /**
    * 允许预渲染
@@ -182,7 +207,7 @@ export default class MIPAccordion extends CustomElement {
   build () {
     let element = this.element
     let type = element.getAttribute('type') || 'automatic'
-    let sections = this.sections = element.querySelectorAll('section')
+    let sections = this.sections = getSections(element)
     let sessionId = this.sessionId = element.getAttribute('sessions-key')
     let sessionKey = this.sessionKey = `MIP-${sessionId}-${location.href}`
     let currentState = getSession.apply(this)
@@ -268,9 +293,9 @@ export default class MIPAccordion extends CustomElement {
             ele: targetContent,
             type: 'fold',
             transitionTime: aniTime,
-            cbFun: function (dom) {
-              dom.setAttribute(ARIA_EXPANDED_ATTRIBUTE, CLOSE_STATUS)
-            }.bind(undefined, targetContent)
+            cbFun: function () {
+              targetContent.setAttribute(ARIA_EXPANDED_ATTRIBUTE, CLOSE_STATUS)
+            }// .bind(undefined, targetContent)
           })
 
           sections.forEach(section => {
@@ -299,7 +324,10 @@ export default class MIPAccordion extends CustomElement {
               heightAni({
                 ele: content,
                 type: 'fold',
-                transitionTime: aniTime
+                transitionTime: aniTime,
+                cb: function () {
+                  util.css(content, 'height', '')
+                }
               })
             })
           }
@@ -321,7 +349,10 @@ export default class MIPAccordion extends CustomElement {
             ele: targetContent,
             type: 'unfold',
             oriHeight: 0,
-            transitionTime: aniTime
+            transitionTime: aniTime,
+            cb: function () {
+              util.css(targetContent, 'height', '')
+            }
           })
 
           setSession(sessionKey, targetId, true)


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#415 
**1、升级点** （清晰准确的描述升级的功能点）
1. 修复 mip 组件嵌套会被 accordion 影响到的问题
2. 修复 accordion 在 section 嵌套的情况下子 section 展开高度无法撑开父 section 的bug

**2、影响范围** （描述该需求上线会影响什么功能）
mip-accordion

**3、自测 checklist**
1. mip-accordion 组件嵌套时相互之间不受影响
2. section 嵌套时子 section 能正常展开父 section

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



