### PR TITLE
修复 IOS9 下面 mip-scrollbox 样式不对的 bug

### DIFF
--- a/components/mip-scrollbox/mip-scrollbox.js
+++ b/components/mip-scrollbox/mip-scrollbox.js
@@ -47,7 +47,8 @@ export default class MIPScrollbox extends CustomElement {
    */
   build () {
     let element = this.element
-    let config = Object.assign({}, DEFAULTS, element.dataset)
+    // 不能用 Object.assign 不然的话 element.dataset 不能拷贝过来
+    let config = util.fn.extend({}, DEFAULTS, element.dataset)
     let updateView = util.fn.throttle(() => viewport.trigger('changed'), 200)
 
     // 绑定滚动事件触发更新视图

--- a/components/mip-scrollbox/mip-scrollbox.js
+++ b/components/mip-scrollbox/mip-scrollbox.js
@@ -72,9 +72,14 @@ export default class MIPScrollbox extends CustomElement {
 
     // 这个 for 循序是需要用到通过上面 for 循序计算出来的总的 width
     nodesArr.forEach(node => {
-      node.style.width = (node.dataset.col || 3) * config.rate / width * 100 + '%'
-      node.style.paddingRight = config.right / cols + '%'
+      util.css(node, {
+        width: (node.dataset.col || 3) * config.rate / width * 100 + '%',
+        paddingRight: config.right / cols + '%'
+      })
     })
-    element.querySelector('[data-scroller]').style.width = width + '%'
+    util.css(element.querySelector('[data-scroller]'), {
+      width: width + '%'
+    })
+    // element.querySelector('[data-scroller]').style.width = width + '%'
   }
 }


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#494 
**1、升级点** （清晰准确的描述升级的功能点）
Object.assign 改成 util.fn.extend
**2、影响范围** （描述该需求上线会影响什么功能）
mip-scrollbox
**3、自测 checklist**

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



