### PR TITLE
小说 nocache 机制完成

### DIFF
--- a/components/mip-shell-xiaoshuo/ad/strategyControl.js
+++ b/components/mip-shell-xiaoshuo/ad/strategyControl.js
@@ -33,8 +33,8 @@ function needNoCache (pageType) {
         }
       })
   } else {
-    isNeedNoCache = false
-    pageNoCacheType = []
+    isNeedNoCache = true
+    pageNoCacheType = pageType
   }
   // 特殊处理
   pageNoCacheType = deletePage(pageNoCacheType)
@@ -45,13 +45,14 @@ function needNoCache (pageType) {
 }
 /**
  * 去掉 page 和 page_1，主要是这个 page 类型，每次都会被算进来，nocache 需要去掉这个类型
+ * 2019-2-28: 增加 page_1，加上这个配置不会有影响
  *
  * @param {Array} pageNoCacheType 当前页面的类型
  * @returns {Array} 去掉相应内容的数组
  */
 function deletePage (pageNoCacheType) {
   return pageNoCacheType.reduce((acc, val) => {
-    if (val !== 'page' && val !== 'page_1') {
+    if (val !== 'page') {
       acc.push(val)
     }
     return acc

--- a/components/mip-shell-xiaoshuo/ad/strategyControl.js
+++ b/components/mip-shell-xiaoshuo/ad/strategyControl.js
@@ -33,8 +33,8 @@ function needNoCache (pageType) {
         }
       })
   } else {
-    isNeedNoCache = true
-    pageNoCacheType = pageType
+    isNeedNoCache = false
+    pageNoCacheType = []
   }
   // 特殊处理
   pageNoCacheType = deletePage(pageNoCacheType)
@@ -44,7 +44,7 @@ function needNoCache (pageType) {
   return [isNeedNoCache, pageNoCacheType]
 }
 /**
- * 去掉 page 和 page_1
+ * 去掉 page 和 page_1，主要是这个 page 类型，每次都会被算进来，nocache 需要去掉这个类型
  *
  * @param {Array} pageNoCacheType 当前页面的类型
  * @returns {Array} 去掉相应内容的数组

--- a/components/mip-shell-xiaoshuo/ad/strategyControl.js
+++ b/components/mip-shell-xiaoshuo/ad/strategyControl.js
@@ -173,6 +173,10 @@ export default class strategyControl {
     if (getHashData('srcid')) {
       Object.assign(novelData, {frsrcid: getHashData('srcid')})
     }
+    // 2019-2-26 特殊逻辑，有了 cache 和 nocache 之后，cache 页只有 page 类型，其他类型都不需要 cache 广告，因此为 false
+    if (pageType === 'detail') {
+      novelData.isNeedAds = false
+    }
     return novelData
   }
 

--- a/components/mip-shell-xiaoshuo/ad/strategyControl.js
+++ b/components/mip-shell-xiaoshuo/ad/strategyControl.js
@@ -9,9 +9,65 @@ import {Constant} from '../common/constant-config'
 import state from '../common/state'
 import {getCurrentWindow, getRootWindow, getHashData} from '../common/util'
 import {
-  initFirstFetchCache
+  initFirstFetchCache,
+  computeNoCacheAds,
+  getCurPageType
 } from './strategyCompute'
-
+/**
+ * 根据页面类型和之前的 schema 判断是否需要广告请求
+ *
+ * @param {string} pageType 页面类型
+ * @returns {Array} 第一个值是 true 则需要广告，否则反之；第二个值是当前页面类型集合
+ */
+function needNoCache (pageType) {
+  let {novelInstance} = state(getCurrentWindow())
+  let pageNoCacheType = []
+  let isNeedNoCache = false
+  if (novelInstance.nocache) {
+    let noCachePageType = (novelInstance.nocache.schema && novelInstance.nocache.schema['page_nocache_ads']) || {}
+    Object.keys(noCachePageType)
+      .forEach(v => {
+        if (pageType.indexOf(v) !== -1) {
+          isNeedNoCache = true
+          pageNoCacheType.push(v)
+        }
+      })
+  } else {
+    isNeedNoCache = true
+    pageNoCacheType = pageType
+  }
+  // 特殊处理
+  pageNoCacheType = deletePage(pageNoCacheType)
+  if (isNeedNoCache === false) {
+    pageNoCacheType = []
+  }
+  return [isNeedNoCache, pageNoCacheType]
+}
+/**
+ * 去掉 page 和 page_1
+ *
+ * @param {Array} pageNoCacheType 当前页面的类型
+ * @returns {Array} 去掉相应内容的数组
+ */
+function deletePage (pageNoCacheType) {
+  return pageNoCacheType.reduce((acc, val) => {
+    if (val !== 'page' && val !== 'page_1') {
+      acc.push(val)
+    }
+    return acc
+  }, [])
+}
+/**
+ * 把 nocache 的模板加入 cache 的广告数据中
+ *
+ * @param {Object} adStrategyCacheData cache 的广告数据
+ * @param {Array} template nocache 的模板
+ * @returns {Object} 汇总的广告数据
+ */
+function addNoCacheTemplate (adStrategyCacheData, template) {
+  adStrategyCacheData.template = adStrategyCacheData.template.concat(template)
+  return adStrategyCacheData
+}
 export default class strategyControl {
   constructor (config) {
     this.globalAd = false
@@ -26,6 +82,7 @@ export default class strategyControl {
     // 梳理广告的novelData
     let novelData = this.getNovelData()
     const currentWindow = getCurrentWindow()
+    const rootWindow = getRootWindow(currentWindow)
     const {currentPage, rootPageId} = state(currentWindow)
     this.changeStrategy()
     let data = {
@@ -46,7 +103,6 @@ export default class strategyControl {
     }
     // 页内的广告
     if (this.pageAd) {
-      const rootWindow = getRootWindow(currentWindow)
       rootWindow.MIP.viewer.page.broadcastCustomEvent({
         name: 'showAdvertising',
         data
@@ -54,6 +110,11 @@ export default class strategyControl {
     }
     // 只发请求，忽略该次的任何操作
     if (novelData.ignoreSendLog && novelData.showedAds) {
+      // nocache 也要设置为false
+      let novelData = this.getNovelData()
+      novelData.isNeedNoCache = false
+      novelData.pageNoCacheType = []
+      Object.assign(data, {novelData})
       window.MIP.viewer.page.emitCustomEvent(currentWindow, false, {
         name: 'ignoreSendLogFetch',
         data
@@ -71,6 +132,8 @@ export default class strategyControl {
     const isNeedAds = novelInstance.adsCache == null ? true : novelInstance.adsCache.isNeedAds
     const novelInstanceId = novelInstance.novelInstanceId
     const latestChapterId = novelInstance.catalog.getLatestChapterId()
+    let [CurPageType] = getCurPageType()
+    let [isNeedNoCache, pageNoCacheType] = needNoCache(CurPageType)
     // 基础novelData数据
     let novelData = {
       isLastPage,
@@ -84,7 +147,9 @@ export default class strategyControl {
       silentFollow: isRootPage,
       isNeedAds,
       novelInstanceId,
-      latestChapterId
+      latestChapterId,
+      isNeedNoCache,
+      pageNoCacheType
     }
     // TODO: 当结果页卡片入口为断点续读时，添加entryFrom: 'from_nvl_toast', 需要修改SF里记录到hash里，等SF修改完成，此处添加
     // 当第二次翻页时候，需要告知后端出品专广告
@@ -147,8 +212,7 @@ export default class strategyControl {
    */
   eventAllPageHandler () {
     const currentWindow = getCurrentWindow()
-    const {isRootPage} = state(currentWindow)
-    const rootWindow = isRootPage ? window : window.parent
+    const rootWindow = getRootWindow(currentWindow)
 
     let listen = function (target, name, handler) {
       target.addEventListener(name, handler)
@@ -223,14 +287,28 @@ export default class strategyControl {
         // 第一次请求的时候需要初始化fetch的数据，并且计算出当前的广告数据
         initFirstFetchCache(adData, novelInstance)
       }
-      const adStrategyCacheData = novelInstance.adsCache.adStrategyCacheData
-      // 计算出需要出的广告数据
+      novelInstance.nocache = computeNoCacheAds(adData, novelInstance.nocache)
+      let adStrategyCacheData = novelInstance.adsCache.adStrategyCacheData
+      addNoCacheTemplate(adStrategyCacheData, novelInstance.nocache.template)
+      // 计算出需要出的广告数据，这个纯粹是为了发 ignore 日志的，因为 custom 只会监听一次 showAdvertising
       if (novelInstance.adsCache != null && novelInstance.adsCache.isFirstFetch) {
         this.strategyStatic()
       }
       window.MIP.viewer.page.emitCustomEvent(currentWindow, false, {
         name: 'showAdStrategyCache',
         data: adStrategyCacheData
+      })
+    })
+    // 不是第一次请求，所以需要将 noCache 的广告数据回传给 mip-custom
+    window.addEventListener('noCacheAdDataReady', e => {
+      let adData = (e && e.detail && e.detail[0]) || {}
+      let currentWindow = getCurrentWindow()
+      let {novelInstance = {}} = state(currentWindow)
+      // 计算 nocache 的广告
+      novelInstance.nocache = computeNoCacheAds(adData, novelInstance.nocache)
+      addNoCacheTemplate(novelInstance.adsCache.adStrategyCacheData, novelInstance.nocache.template)
+      window.MIP.viewer.page.emitCustomEvent(currentWindow, false, {
+        name: 'addNoCacheAds'
       })
     })
   }

--- a/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.js
+++ b/components/mip-shell-xiaoshuo/mip-shell-xiaoshuo.js
@@ -165,6 +165,7 @@ export default class MipShellNovel extends MIP.builtinComponents.MipShell {
     sendWebbLogLink(document.querySelector('.navigator a:last-child'), 'nextPageButton')
     // 用来记录翻页的次数，主要用来触发品专的广告
     novelInstance.novelPageNum++
+    // 目前除了 page 就 detail 是单独的，page_2 也是 page 的一种
     if (novelInstance.currentPageMeta.pageType === 'page') {
       if (novelInstance.readPageNum == null) {
         novelInstance.readPageNum = 1


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）
#531 

**2、影响范围** （描述该需求上线会影响什么功能）
新增机制，对线上无影响

**3、自测 checklist**
和后端联调通过

需要配合新的 mip-custom 一起测试联调

主要测试点：
1、每个页面根据 schema 算出需要出的广告，并且页面正常展现广告，下面分别是 cache 和 nocache 的典型 schema
![cache](https://user-images.githubusercontent.com/41358202/53384548-3e167100-39b6-11e9-8a9f-696557f65bcf.png)

![nocache](https://user-images.githubusercontent.com/41358202/53384592-69995b80-39b6-11e9-957f-e52935aa630e.png)

2、根据上图可知：现在 cache 机制下只有 page 页面类型，其他页面类型（包括详情页）都在 nocache 机制下进行，schema 的计算方式和原来一样，只是广告数据存储的字段不一样了，cache 机制的广告在 ads 字段，nocache 机制的广告在 nocacheads，如下图：
![image](https://user-images.githubusercontent.com/41358202/53384815-2095d700-39b7-11e9-9bba-5620d9b88560.png)


3、cache 机制和 nocache 机制互不影响，也就是说 page 和 page_8 或chapterEnd 可以共存，这几种页面类型的广告可以叠加显示

4、在后台不上线的情况下（即直接使用现在线上数据的情况），上线顺序相关的测试：1）只更新shell-xiaoshuo，不更新mip-custom，线上应该正常；2）二者都更新，线上也应该正常。

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



