### PR TITLE
没有品专广告数据时返回error，变更参数使其暂时正常

### DIFF
--- a/components/mip-shell-xiaoshuo/ad/strategyControl.js
+++ b/components/mip-shell-xiaoshuo/ad/strategyControl.js
@@ -44,6 +44,20 @@ function needNoCache (pageType) {
   return [isNeedNoCache, pageNoCacheType]
 }
 /**
+ * 判断是否是品专广告，目前品专广告只有 page_x 才会出现
+ *
+ * @param {Array} pageNoCacheType 判断需要 nocache 广告的页面类型
+ * @returns {boolean} 布尔值
+ */
+function isPinZhuan (pageNoCacheType) {
+  for (let index = 0; index < pageNoCacheType.length; index++) {
+    if (pageNoCacheType[index].indexOf('page_') !== -1) {
+      return true
+    }
+  }
+  return false
+}
+/**
  * 去掉 page 和 page_1，主要是这个 page 类型，每次都会被算进来，nocache 需要去掉这个类型
  * 2019-2-28: 增加 page_1，加上这个配置不会有影响
  *
@@ -130,7 +144,7 @@ export default class strategyControl {
     const officeId = novelInstance.currentPageMeta.officeId || ''
     const novelPageNum = novelInstance.novelPageNum || ''
     const pageType = novelInstance.currentPageMeta.pageType || ''
-    const isNeedAds = novelInstance.adsCache == null ? true : novelInstance.adsCache.isNeedAds
+    let isNeedAds = novelInstance.adsCache == null ? true : novelInstance.adsCache.isNeedAds
     const novelInstanceId = novelInstance.novelInstanceId
     const latestChapterId = novelInstance.catalog.getLatestChapterId()
     let [CurPageType] = getCurPageType()
@@ -151,6 +165,11 @@ export default class strategyControl {
       latestChapterId,
       isNeedNoCache,
       pageNoCacheType
+    }
+    // 2019-03-05 临时增加：isNeedAds 在 isNeedNoCache 为 true 需要品专广告的时候，强行变更其值为 true
+    if (novelData.isNeedNoCache && isPinZhuan(novelData.pageNoCacheType)) {
+      novelData.isNeedAds = true
+      isNeedAds = true
     }
     // TODO: 当结果页卡片入口为断点续读时，添加entryFrom: 'from_nvl_toast', 需要修改SF里记录到hash里，等SF修改完成，此处添加
     // 当第二次翻页时候，需要告知后端出品专广告


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

#551 

**1、升级点** （清晰准确的描述升级的功能点）

**2、影响范围** （描述该需求上线会影响什么功能）
修复page_8不展现凤巢广告的问题

**3、自测 checklist**
代理测试，线上 page_8 可以正常出凤巢广告，但是品专广告目前还没有数据，不能展现。

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



