### PR TITLE
修复 ios8 下，播放按钮无法显示的 bug

### DIFF
--- a/components/mip-audio/mip-audio.less
+++ b/components/mip-audio/mip-audio.less
@@ -35,11 +35,11 @@ mip-audio.mip-audio-default-style {
   }
 
   [play-button].mip-audio-stopped-icon {
-    background-image: url('https://mipcache.bdstatic.com/static/static/auido/audioimg.png');
+    background-image: url('https://c.mipcdn.com/static/static/auido/audioimg.png');
   }
 
   [play-button].mip-audio-playing-icon {
-    background-image: url('https://mipcache.bdstatic.com/static/static/auido/audioimg.png');
+    background-image: url('https://c.mipcdn.com/static/static/auido/audioimg.png');
     background-position: -22px 0;
   }
 

--- a/components/mip-audio/mip-audio.less
+++ b/components/mip-audio/mip-audio.less
@@ -29,22 +29,18 @@ mip-audio.mip-audio-default-style {
     width: 20px;
     min-width: 20px;
     height: 20px;
-    box-sizing: content-box;
-    padding: 10px;
-    margin: -10px;
     background-size: 42px 20px;
-    background-clip: content-box;
     flex: 0 0 auto;
+    display: inline-block;
   }
 
   [play-button].mip-audio-stopped-icon {
     background-image: url('https://mipcache.bdstatic.com/static/static/auido/audioimg.png');
-    background-position: 9px 11px;
   }
 
   [play-button].mip-audio-playing-icon {
     background-image: url('https://mipcache.bdstatic.com/static/static/auido/audioimg.png');
-    background-position: -13px 11px;
+    background-position: -22px 0;
   }
 
   [seekbar] {


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

修复 `<mip-audio>` 在 iOS 8 下无法显示播放按钮的 bug

**2、影响范围** （描述该需求上线会影响什么功能）

所有使用 `<mip-audio>` 的页面

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



