### PR TITLE
修复小说MIP从详情页进入内页时不打adShow日志的问题

### DIFF
--- a/components/mip-shell-xiaoshuo/common/log.js
+++ b/components/mip-shell-xiaoshuo/common/log.js
@@ -7,7 +7,6 @@ import {getCurrentWindow, getRootWindow, getParamFromString} from './util'
 import state from './state'
 
 const {isRootPage, novelInstance, originalUrl} = state(window)
-const pageType = novelInstance ? novelInstance.currentPageMeta.pageType : ''
 
 /**
  * 发送webb性能日志
@@ -67,7 +66,7 @@ export function getSiteInfo () {
   let isZongheng = zonghengPattern.test(originalUrl)
   let site
   isZongheng ? site = 'zongheng' : site = 'iqiyi'
-  return {site, pageType}
+  return {site, pageType: novelInstance ? novelInstance.currentPageMeta.pageType : ''}
 }
 
 /**
@@ -114,7 +113,7 @@ export function showAdLog () {
    * @param {string} newVal 改变后的值
   */
   function observer (oldVal, newVal) {
-    if ((newVal === true) && (pageType !== 'detail')) {
+    if (newVal === true) {
       sendTCLog('interaction', {
         type: 'o',
         action: 'adShow'


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#584
**1、升级点** （清晰准确的描述升级的功能点）
修复小说MIP从详情页进入内页时不打adShow日志的问题
**2、影响范围** （描述该需求上线会影响什么功能）
从MIP详情页进入广告页
**3、自测 checklist**
从详情页进入广告页，打开 Network，能够看到有 adShow 的 tc 日志
**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百



