### PR TITLE
[fix] 修改 mip-map 将 BMap 挂载到沙盒对象上的方法

### DIFF
--- a/components/mip-map/mip-map.js
+++ b/components/mip-map/mip-map.js
@@ -128,10 +128,6 @@ export default class MIPMap extends CustomElement {
       window.BMap = {}
       window.BMap._insertScript = new Promise(resolve => {
         window._initBaiduMap = () => {
-          window.document.body.removeChild(script)
-          window.BMap._insertScript = null
-          window._initBaiduMap = null
-
           // 把百度地图的参数挂到 BMap.CONSTANTS 上
           window.BMap.CONSTANTS = Object.keys(window)
             .filter(key => key.indexOf('BMAP_') === 0)
@@ -141,6 +137,9 @@ export default class MIPMap extends CustomElement {
             }, {})
 
           resolve(window.BMap)
+          window.document.body.removeChild(script)
+          window.BMap._insertScript = null
+          window._initBaiduMap = null
         }
         let script = document.createElement('script')
         window.document.body.appendChild(script)

--- a/components/mip-map/mip-map.js
+++ b/components/mip-map/mip-map.js
@@ -152,12 +152,7 @@ export default class MIPMap extends CustomElement {
     let BMap = window.BMap
 
     // BMap注入沙盒
-    Object.defineProperty(sandbox, 'BMap', {
-      value: BMap,
-      writable: false,
-      enumerable: true,
-      configurable: true
-    })
+    sandbox.BMap = BMap
 
     // 派发事件
     viewer.eventAction.execute('loaded', this.element, {})

--- a/components/mip-map/mip-map.js
+++ b/components/mip-map/mip-map.js
@@ -128,10 +128,19 @@ export default class MIPMap extends CustomElement {
       window.BMap = {}
       window.BMap._insertScript = new Promise(resolve => {
         window._initBaiduMap = () => {
-          resolve(window.BMap)
           window.document.body.removeChild(script)
           window.BMap._insertScript = null
           window._initBaiduMap = null
+
+          // 把百度地图的参数挂到 BMap.CONSTANTS 上
+          window.BMap.CONSTANTS = Object.keys(window)
+            .filter(key => key.indexOf('BMAP_') === 0)
+            .reduce((obj, key) => {
+              obj[key] = window[key]
+              return obj
+            }, {})
+
+          resolve(window.BMap)
         }
         let script = document.createElement('script')
         window.document.body.appendChild(script)


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
https://github.com/mipengine/mip2/issues/576

**1、升级点** （清晰准确的描述升级的功能点）
1. 修改 mip-map 的挂载方式由 defineProperty 改成直接赋值，避免沙盒变量增减造成的 redefine 错误

**2、影响范围** （描述该需求上线会影响什么功能）
1. mip-map
2. 线上蓝犀牛

**3、自测 checklist**
1. mip-map 正常工作
2. MIP.sandbox.BMap 正常访问

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



