### PR TITLE
fixed: 修复 mip-fixed 在 iOS + iframe 下的问题 #615

### DIFF
--- a/components/mip-city-selection/mip-city-selection.js
+++ b/components/mip-city-selection/mip-city-selection.js
@@ -225,7 +225,7 @@ export default class MIPCitySelection extends CustomElement {
    */
   renderCityNav (wrapper) {
     let listData = this.list
-    let html = [`<mip-fixed class="mip-city-selection-sidebar-wrapper" type="right">
+    let html = [`<mip-fixed still class="mip-city-selection-sidebar-wrapper" type="right">
       <div class="mip-city-selection-sidebar">`
     ]
 

--- a/components/mip-confirm/example/mip-confirm1.html
+++ b/components/mip-confirm/example/mip-confirm1.html
@@ -7,11 +7,22 @@
     <link rel="canonical" href="对应的原页面地址">
     <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
     <style mip-custom>
+      button {
+        display: block;
+        margin: 20px auto;
+        width: 120px;
+        height: 50px;
+        line-height: 50px;
+        font-size: 14px;
+        background: blue;
+        color: #fff;
+      }
     </style>
   </head>
   <body>
     <div>
-     <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>
+      <button on="tap:confirm.show">打开弹窗</button>
+      <mip-test id="confirmTest"></mip-test>
       <mip-confirm
         id= "confirm"
         pattern="confirm"
@@ -23,6 +34,6 @@
     </div>
     <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
     <script src="/mip-confirm/mip-confirm.js"></script>
-    <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
+    <script src="./mip-test.js"></script>
   </body>
 </html>

--- a/components/mip-confirm/example/mip-confirm2.html
+++ b/components/mip-confirm/example/mip-confirm2.html
@@ -7,15 +7,24 @@
     <link rel="canonical" href="对应的原页面地址">
     <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
     <style mip-custom>
+      button {
+        display: block;
+        margin: 20px auto;
+        width: 120px;
+        height: 50px;
+        line-height: 50px;
+        font-size: 14px;
+        background: blue;
+        color: #fff;
+      }
     </style>
   </head>
   <body>
     <div>
-     <mip-test id="confirmTest"  on="show:confirm.show"></mip-test>
+      <button on="tap:confirm.show">打开弹窗</button>
       <mip-confirm
         id= "confirm"
         pattern="alert"
-        on="ready:confirmTest.print"
         info-title="提示"
         info-text="confirm 类型的弹窗。这里是弹窗的提示信息内容，问题问题问题问题"
       >
@@ -23,6 +32,6 @@
     </div>
     <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
     <script src="/mip-confirm/mip-confirm.js"></script>
-    <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
+    <script src="./mip-test.js"></script>
   </body>
 </html>

--- a/components/mip-confirm/example/mip-test.js
+++ b/components/mip-confirm/example/mip-test.js
@@ -1,0 +1,29 @@
+/**
+ * @file 测试组件
+ * @author mj(zoumiaojiang@gmail.com)
+ */
+
+/* globals MIP */
+
+class MIPTest extends MIP.CustomElement {
+  build () {
+    this.addEventAction('print', data => {
+      this.print(data)
+    })
+  }
+
+  /**
+   * 打印的测试内容
+   *
+   * @param {any} content 打印的内容
+   */
+  print (content) {
+    if (typeof content === 'object') {
+      content = JSON.stringify(content, null, 2)
+    }
+
+    this.element.innerHTML = '<code><pre>' + content + '</pre></code>'
+  }
+}
+
+MIP.registerElement('mip-test', MIPTest)

--- a/components/mip-confirm/mip-confirm.js
+++ b/components/mip-confirm/mip-confirm.js
@@ -1,97 +1,86 @@
+/**
+ * @file mip-confirm 组件
+ * @author yanshi
+ */
+
 import './mip-confirm.less'
+
+/* global MIP */
 
 const {CustomElement, viewer} = MIP
 
 export default class MIPConfirm extends CustomElement {
   constructor (element) {
     super(element)
-    this.confirm = false
-    this.dialog = false
-    this.myDialog = false
-    this.click = false
-    this.cancel = this.cancel.bind(this)
-    this.isOk = this.isOk.bind(this)
+    this.isDialogOpen = false
+    this.cancelHandler = this.cancelHandler.bind(this)
+    this.okHandler = this.okHandler.bind(this)
   }
 
   build () {
     const container = document.createElement('div')
 
-    container.innerHTML = '<mip-fixed type="top left bottom right" class="mask"></mip-fixed>' +
-      '<mip-fixed type="top" class="wrapper">' +
-      '<div class="toast">' +
-      '<div class="confirm-title"></div>' +
-      '<p class="confirm-content"></p>' +
-      '<div class="confirm-footer"></div>' +
-      '</div>' +
-      '</mip-fixed>'
+    container.innerHTML = '' +
+      '<mip-fixed still type="top" class="wrapper">' +
+        '<div class="toast">' +
+        '<div class="confirm-title"></div>' +
+          '<p class="confirm-content"></p>' +
+          '<div class="confirm-footer"></div>' +
+        '</div>' +
+      '</mip-fixed>' +
+      '<mip-fixed still type="top left bottom right" class="mask"></mip-fixed>'
 
     this.container = container
     this.element.appendChild(container)
 
-    const {isDemo, pattern} = this.props
-
-    if (isDemo) {
-      this.click = true
-      this.myDialog = false
-    }
-
-    if (pattern === 'confirm') {
-      this.dialog = false
-      this.confirm = true
-    } else {
-      this.confirm = false
-      this.dialog = true
-    }
-
     this.addEventAction('show', () => {
-      this.myDialog = true
+      this.isDialogOpen = true
       this.render()
     })
     this.addEventAction('hidden', () => {
-      this.myDialog = false
+      this.isDialogOpen = false
       this.render()
     })
 
     this.render()
   }
 
-  cancel () {
+  cancelHandler () {
     viewer.eventAction.execute('ready', this.element, false)
-    this.myDialog = false
-    if (this.isDemo) {
-      this.click = true
-    }
+    this.isDialogOpen = false
     this.render()
   }
 
-  isOk () {
+  okHandler () {
     viewer.eventAction.execute('ready', this.element, true)
-    this.myDialog = false
-    if (this.isDemo) {
-      this.click = true
-    }
+    this.isDialogOpen = false
     this.render()
   }
 
   render () {
-    const {infoTitle, infoText} = this.props
+    const {infoTitle, infoText, pattern} = this.props
+    const ele = this.element
+    const wrapper = document.querySelector('.wrapper')
+    const mask = ele.querySelector('.mask')
 
-    this.container.style.display = this.myDialog ? null : 'none'
-    this.element.querySelector('.confirm-title').innerHTML = `<div>${infoTitle}</div>`
-    this.element.querySelector('.confirm-content').innerText = infoText
+    const footer = ele.querySelector('.confirm-footer')
+    const title = ele.querySelector('.confirm-title')
+    const content = ele.querySelector('.confirm-content')
 
-    const footer = this.element.querySelector('.confirm-footer')
+    wrapper.style.display = this.isDialogOpen ? null : 'none'
+    mask.style.display = this.isDialogOpen ? null : 'none'
 
-    if (this.confirm) {
+    title.innerHTML = `<div>${infoTitle}</div>`
+    content.innerText = infoText
+
+    if (pattern === 'confirm') {
       footer.innerHTML = '<button class="confirm-footer-btn confirm-footer-left">取消</button>' +
         '<button class="confirm-footer-btn confirm-footer-right">确定</button>'
-      footer.querySelector('.confirm-footer-left').addEventListener('click', this.cancel)
-      footer.querySelector('.confirm-footer-right').addEventListener('click', this.isOk)
-    }
-
-    if (this.dialog) {
+      footer.querySelector('.confirm-footer-left').addEventListener('click', this.cancelHandler)
+      footer.querySelector('.confirm-footer-right').addEventListener('click', this.okHandler)
+    } else if (pattern === 'alert') {
       footer.innerHTML = '<button class="confirm-footer-btn confirm-footer-bottom">确定</button>'
-      footer.querySelector('.confirm-footer-bottom').addEventListener('click', this.isOk)
+      footer.querySelector('.confirm-footer-bottom').addEventListener('click', this.okHandler)
     }
   }
 }
@@ -108,9 +97,5 @@ MIPConfirm.props = {
   pattern: {
     type: String,
     default: 'alert'
-  },
-  isDemo: {
-    type: Boolean,
-    default: true
   }
 }

--- a/components/mip-toast/README.md
+++ b/components/mip-toast/README.md
@@ -17,10 +17,7 @@
 1、弹出框 只弹出文字（不传 info-icon-src）
 
 ```html
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
-<mip-test on="show:demo.show"></mip-test>
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
-
+<button on="tap:demo.show"></mip-test>
 <mip-toast
   id= "demo"
   info-text="默认提示框"
@@ -28,17 +25,12 @@
   auto-close = "true"
 >
 </mip-toast>
-  <!--  测试组件，模拟接收和抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
-  <!-- 测试组件，模拟接收和抛出事件 -->
 ```
 
 2、弹出框 弹出带图和文字
 
 ```html
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
-<mip-test on="show:demo.show"></mip-test>
-<!-- mip-test 作为测试组件，模拟接收和抛出事件 -->
+<button on="tap:demo.show"></button>
 <mip-toast
   id= "demo"
   info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
@@ -47,9 +39,6 @@
   auto-close = "true"
 >
 </mip-toast>
-<!-- 测试组件，模拟接收和抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
-<!-- 测试组件，模拟接收和抛出事件 -->
 ```
 
 ## 属性
@@ -76,7 +65,6 @@
 
 默认值：""
 
-
 ### info-text
 
 说明：提示框内容
@@ -96,16 +84,6 @@
 类型 ：`String`
 
 默认值："center"
-
-### auto-close
-
-说明：是否自动关闭
-
-必选项：否
-
-类型 ：`Boolean`
-
-默认值：true
 
 ### close-time
 
@@ -131,8 +109,8 @@
 
 ### show(第二个show)
 
-每次其他组件触发抛出事件后，触发`mip-toast`的`show`事件，并传当前状态是显示
+每次其他组件触发抛出事件后，触发 `mip-toast` 的 `show` 事件，并传当前状态是显示
 
-注意，每次其他组件触发抛出事件后，也可以触发`mip-toast`的`hidden`事件，并传当前状态是隐藏
+注意，每次其他组件触发抛出事件后，也可以触发 `mip-toast` 的 `hidden` 事件，并传当前状态是隐藏
 
 组件间通信请看文档 https://www.mipengine.org/doc/3-widget/6-help/3-mip-normal.html

--- a/components/mip-toast/example/mip-toast.html
+++ b/components/mip-toast/example/mip-toast.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html mip>
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -9,20 +8,30 @@
   <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
   <style mip-custom>
     /* 自定义样式 */
-
+    button {
+      display: block;
+      margin: 20px auto;
+      width: 120px;
+      height: 50px;
+      line-height: 50px;
+      font-size: 14px;
+      background: blue;
+      color: #fff;
+    }
   </style>
 </head>
-
 <body>
   <div>
-    <mip-test on="show:demo.show"></mip-test>
-    <mip-toast id="demo" info-text="默认提示框" station="center" auto-close="true" close-time="2">
+    <button on="tap:demo.show">打开 toast</button>
+    <mip-toast
+      id="demo"
+      info-text="默认提示框"
+      station="center"
+      auto-close="false"
+    >
     </mip-toast>
   </div>
   <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
   <script src="/mip-toast/mip-toast.js"></script>
-  <!-- 测试组件，模拟抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
 </body>
-
 </html>

--- a/components/mip-toast/example/mip-toast1.html
+++ b/components/mip-toast/example/mip-toast1.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html mip>
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -9,21 +8,32 @@
   <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
   <style mip-custom>
     /* 自定义样式 */
-
+    button {
+      display: block;
+      margin: 20px auto;
+      width: 120px;
+      height: 50px;
+      line-height: 50px;
+      font-size: 14px;
+      background: blue;
+      color: #fff;
+    }
   </style>
 </head>
-
 <body>
   <div>
-    <mip-test on="show:demo.show"></mip-test>
-    <mip-toast id="demo" info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png" info-text="默认提示框文字Top+图片"
-      station="top" auto-close="true" close-time="2">
+    <button on="tap:demo.show">打开 toast</button>
+    <mip-toast
+      id="demo"
+      info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
+      info-text="默认提示框文字Top+图片"
+      station="top"
+      auto-close="true"
+      close-time="1"
+    >
     </mip-toast>
   </div>
   <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
   <script src="/mip-toast/mip-toast.js"></script>
-  <!-- 测试组件，模拟抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
 </body>
-
 </html>

--- a/components/mip-toast/example/mip-toast2.html
+++ b/components/mip-toast/example/mip-toast2.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html mip>
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -9,21 +8,32 @@
   <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
   <style mip-custom>
     /* 自定义样式 */
-
+    button {
+      display: block;
+      margin: 20px auto;
+      width: 120px;
+      height: 50px;
+      line-height: 50px;
+      font-size: 14px;
+      background: blue;
+      color: #fff;
+    }
   </style>
 </head>
-
 <body>
   <div>
-    <mip-test on="show:demo.show"></mip-test>
-    <mip-toast id="demo" info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png" info-text="默认提示框文字Center+图片"
-      station="center" auto-close="true" close-time="2">
+    <button on="tap:demo.show">打开 toast</button>
+    <mip-toast
+      id="demo"
+      info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
+      info-text="默认提示框文字Center+图片"
+      station="center"
+      auto-close="true"
+      close-time="2"
+    >
     </mip-toast>
   </div>
   <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
   <script src="/mip-toast/mip-toast.js"></script>
-  <!-- 测试组件，模拟抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
 </body>
-
 </html>

--- a/components/mip-toast/example/mip-toast3.html
+++ b/components/mip-toast/example/mip-toast3.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html mip>
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -9,21 +8,32 @@
   <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
   <style mip-custom>
     /* 自定义样式 */
-
+    button {
+      display: block;
+      margin: 20px auto;
+      width: 120px;
+      height: 50px;
+      line-height: 50px;
+      font-size: 14px;
+      background: blue;
+      color: #fff;
+    }
   </style>
 </head>
-
 <body>
   <div>
-    <mip-test on="show:demo.show"></mip-test>
-    <mip-toast id="demo" info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png" info-text="默认提示框文字Bottom+图片"
-      station="bottom" auto-close="true" close-time="2">
+    <button on="tap:demo.show">打开 toast</button>
+    <mip-toast
+      id="demo"
+      info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
+      info-text="默认提示框文字Bottom+图片"
+      station="bottom"
+      auto-close="true"
+      close-time="2"
+    >
     </mip-toast>
   </div>
   <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
   <script src="/mip-toast/mip-toast.js"></script>
-  <!-- 测试组件，模拟抛出事件 -->
-  <script src="https://caoru828.github.io/my_json/mip-test/mip-test.js"></script>
 </body>
-
 </html>

--- a/components/mip-toast/mip-toast.js
+++ b/components/mip-toast/mip-toast.js
@@ -1,4 +1,11 @@
+/**
+ * @file mip-toast 组件
+ * @author yanshi
+ */
+
 import './mip-toast.less'
+
+/* global MIP */
 
 const {CustomElement} = MIP
 
@@ -23,23 +30,21 @@ export default class MIPToast extends CustomElement {
   }
 
   update () {
-    const {closeTime, infoIconSrc, autoClose} = this.props
+    const {closeTime, infoIconSrc} = this.props
 
-    if (!!closeTime && closeTime !== 2500) {
-      this.showTime = closeTime * 1000
-    }
+    this.showTime = closeTime * 1000
+
     if (!infoIconSrc) {
       this.show = false
     } else {
       this.isBlock = true
       this.hasPic = true
     }
-    if (autoClose) {
-      setTimeout(() => {
-        this.close = false
-        this.render()
-      }, this.showTime)
-    }
+    setTimeout(() => {
+      this.close = false
+      this.render()
+    }, this.showTime)
+
     this.render()
   }
 
@@ -72,10 +77,13 @@ export default class MIPToast extends CustomElement {
     wrapper.appendChild(fixed)
 
     fixed.setAttribute('type', 'top')
+    fixed.setAttribute('still', true)
     fixed.classList.add(station)
+
     if (!this.close) {
       fixed.style.display = 'none'
     }
+
     fixed.appendChild(toastWrapper)
 
     if (this.hasPic) {
@@ -111,13 +119,9 @@ MIPToast.props = {
     type: String,
     default: ''
   },
-  autoClose: {
-    type: Boolean,
-    default: true
-  },
   closeTime: {
     type: Number,
-    default: 2500
+    default: 3
   },
   station: {
     type: String,


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#615 
**1、升级点** （清晰准确的描述升级的功能点）

bugfix：mip-fixed 在 iOS + iframe 环境下会被移动到 body 之外导致  DOM 操作报错

**2、影响范围** （描述该需求上线会影响什么功能）

mip-toast, mip-confirm, mip-city-selection

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



