### PR TITLE
fix: 修复 mip-selector 和 mip-anim 组件 README 文件里不可见的 img

### DIFF
--- a/components/mip-anim/README.md
+++ b/components/mip-anim/README.md
@@ -12,7 +12,7 @@
 
 ```html
 <mip-anim width=400 height=300 src="my-gif.gif">
-  <mip-img placeholder width=400 height=300 src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg">
+  <mip-img placeholder width=400 height=300 src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg">
   </mip-img>
 </mip-anim>
 ```
@@ -24,22 +24,22 @@
 ### 带 `placeholder` 的加载方式
 
 ```html
-<mip-anim layout="fixed" width=210 height=210 src="http://boscdn.bpc.baidu.com/v1/assets/mipengine/sample.gif" alt="an animation">
-   <mip-img placeholder class="background" layout="fixed-height" width=210 height=210 src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>
+<mip-anim layout="fixed" width=210 height=210 src="https://boscdn.bpc.baidu.com/v1/assets/mipengine/sample.gif" alt="an animation">
+   <mip-img placeholder class="background" layout="fixed-height" width=210 height=210 src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>
 </mip-anim>
 ```
 
 ### 只有 GIF 图
 
 ```html
-<mip-anim layout="fixed" width=210 height=210 src="http://boscdn.baidu.com/v1/assets/mipengine/sample.gif" alt="an animation"></mip-anim>
+<mip-anim layout="fixed" width=210 height=210 src="https://boscdn.baidu.com/v1/assets/mipengine/sample.gif" alt="an animation"></mip-anim>
 ```
 
 ### 不指定 URL
 
 ```html
 <mip-anim layout="fixed" width=210 height=210  alt="an animation">
-   <mip-img placeholder class="background" layout="fixed-height" width=210 height=210 src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>
+   <mip-img placeholder class="background" layout="fixed-height" width=210 height=210 src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>
 </mip-anim>
 ```
 

--- a/components/mip-anim/README.md
+++ b/components/mip-anim/README.md
@@ -12,7 +12,7 @@
 
 ```html
 <mip-anim width=400 height=300 src="my-gif.gif">
-  <mip-img placeholder width=400 height=300 src="my-gif-screencap.jpg">
+  <mip-img placeholder width=400 height=300 src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg">
   </mip-img>
 </mip-anim>
 ```

--- a/components/mip-anim/example/mip-anim.html
+++ b/components/mip-anim/example/mip-anim.html
@@ -28,17 +28,17 @@
 
 <pre class="code">&lt;mip-anim
   width=&quot;300&quot; height=&quot;200&quot;
-  src=&quot;http://boscdn.baidu.com/v1/assets/mipengine/sample.gif&quot;
+  src=&quot;https://boscdn.baidu.com/v1/assets/mipengine/sample.gif&quot;
   alt=&quot;动图加载失败&quot;&gt;
   &lt;mip-img placeholder class=&quot;background&quot; width=&quot;210&quot; height=&quot;210&quot;
-    src=&quot;http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg&quot;
+    src=&quot;https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg&quot;
     alt=&quot;图片加载失败&quot;&gt;
   &lt;/mip-img&gt;
 &lt;/mip-anim&gt;</pre>
 
 <div>
-  <mip-anim width="300" height="200" src="http://boscdn.baidu.com/v1/assets/mipengine/sample.gif" alt="动图加载失败">
-    <mip-img placeholder class="background" width="210" height="210" src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"
+  <mip-anim width="300" height="200" src="https://boscdn.baidu.com/v1/assets/mipengine/sample.gif" alt="动图加载失败">
+    <mip-img placeholder class="background" width="210" height="210" src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"
       alt="图片加载失败">
     </mip-img>
   </mip-anim>
@@ -48,12 +48,12 @@
 
 <pre class="code">&lt;mip-anim
   width=&quot;300&quot; height=&quot;200&quot;
-  src=&quot;http://boscdn.baidu.com/v1/assets/mipengine/sample.gif&quot;
+  src=&quot;https://boscdn.baidu.com/v1/assets/mipengine/sample.gif&quot;
   alt=&quot;动图加载失败&quot;&gt;
 &lt;/mip-anim&gt;</pre>
 
 <div>
-  <mip-anim width="300" height="200" src="http://boscdn.baidu.com/v1/assets/mipengine/sample.gif" alt="动图加载失败">
+  <mip-anim width="300" height="200" src="https://boscdn.baidu.com/v1/assets/mipengine/sample.gif" alt="动图加载失败">
   </mip-anim>
 </div>
 
@@ -63,14 +63,14 @@
   width=&quot;300&quot; height=&quot;200&quot;
   alt=&quot;动图加载失败&quot;&gt;
   &lt;mip-img placeholder class=&quot;background&quot; width=&quot;210&quot; height=&quot;210&quot;
-    src=&quot;http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg&quot;
+    src=&quot;https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg&quot;
     alt=&quot;图片加载失败&quot;&gt;
   &lt;/mip-img&gt;
 &lt;/mip-anim&gt;</pre>
 
 <div>
   <mip-anim width="300" height="200" alt="图片加载失败">
-    <mip-img placeholder width="300" height="200" src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"
+    <mip-img placeholder width="300" height="200" src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"
       alt="图片加载失败"></mip-img>
   </mip-anim>
 </div>

--- a/components/mip-selector/README.md
+++ b/components/mip-selector/README.md
@@ -14,10 +14,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container">
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -25,10 +25,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container" multiple>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -36,10 +36,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container">
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3" disabled></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3" disabled></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -47,10 +47,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container" disabled>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -74,12 +74,12 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container" id="actionsSample">
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="5"></mip-img>
-  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="6"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="5"></mip-img>
+  <mip-img src="https://boscdn.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="6"></mip-img>
 </mip-selector>
 
 <button on="tap:actionsSample.clear">清空选项 clear()</button>

--- a/components/mip-selector/README.md
+++ b/components/mip-selector/README.md
@@ -14,10 +14,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container">
-  <mip-img src="./imgs/img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="./imgs/img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="./imgs/img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="./imgs/img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -25,10 +25,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container" multiple>
-  <mip-img src="./imgs/img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="./imgs/img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="./imgs/img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="./imgs/img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -36,10 +36,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container">
-  <mip-img src="./imgs/img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="./imgs/img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="./imgs/img3.png" width="60" height="60" option="3" disabled></mip-img>
-  <mip-img src="./imgs/img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3" disabled></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -47,10 +47,10 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container" disabled>
-  <mip-img src="./imgs/img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="./imgs/img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="./imgs/img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="./imgs/img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
 </mip-selector>
 ```
 
@@ -74,12 +74,12 @@ mip 的一个选择器控件类型组件
 
 ```html
 <mip-selector class="sample-selector" layout="container" id="actionsSample">
-  <mip-img src="./imgs/img1.png" width="60" height="60" option="1"></mip-img>
-  <mip-img src="./imgs/img2.png" width="60" height="60" option="2"></mip-img>
-  <mip-img src="./imgs/img3.png" width="60" height="60" option="3"></mip-img>
-  <mip-img src="./imgs/img4.png" width="60" height="60" option="4"></mip-img>
-  <mip-img src="./imgs/img1.png" width="60" height="60" option="5"></mip-img>
-  <mip-img src="./imgs/img2.png" width="60" height="60" option="6"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="1"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="2"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img3.png" width="60" height="60" option="3"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img4.png" width="60" height="60" option="4"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img1.png" width="60" height="60" option="5"></mip-img>
+  <mip-img src="http://bos.nj.bpc.baidu.com/v1/assets/mip/temp/mip-selector-img2.png" width="60" height="60" option="6"></mip-img>
 </mip-selector>
 
 <button on="tap:actionsSample.clear">清空选项 clear()</button>


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）
修复 mip-selector 和 mip-anim 组件 README 文件里不可见的 img

**2、影响范围** （描述该需求上线会影响什么功能）
影响官方网站组件的演示效果，修复之前有几个图片加载不到，修复后可见
**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



