### PR TITLE
判断当前域名或referrer，从而加个参数noshell

### DIFF
--- a/components/mip-custom/common/url.js
+++ b/components/mip-custom/common/url.js
@@ -129,8 +129,8 @@ const getSourceId = () => {
  * @returns {boolean} 返回布尔值
  */
 const isFromBaidu = () => {
-  return matchDomain(window.location.href, '.baidu') ||
-    matchDomain(document.referrer, '.baidu')
+  return matchDomain(window.location.href, '.baidu.com') ||
+    matchDomain(document.referrer, '.baidu.com')
 }
 /**
  * 当前域名为 mipcdn
@@ -138,7 +138,7 @@ const isFromBaidu = () => {
  * @returns {boolean} 返回布尔值
  */
 const isMIPCdn = () => {
-  return matchDomain(window.location.href, '.mipcdn')
+  return matchDomain(window.location.href, '.mipcdn.com')
 }
 /**
  * 判断链接是否是某个域名

--- a/components/mip-custom/common/url.js
+++ b/components/mip-custom/common/url.js
@@ -133,12 +133,12 @@ const isFromBaidu = () => {
     matchDomain(document.referrer, '.baidu.com')
 }
 /**
- * 当前域名为 mipcdn
+ * 当前链接为 mip cache 链接
  *
  * @returns {boolean} 返回布尔值
  */
-const isMIPCdn = () => {
-  return matchDomain(window.location.href, '.mipcdn.com')
+const isCacheUrl = () => {
+  return window.MIP.util.isCacheUrl(location.href)
 }
 /**
  * 判断链接是否是某个域名
@@ -187,7 +187,7 @@ const get = (el, poi) => {
 
   // 非mip-shell增加noshell参数
   // 非百度域且不是mip cache链接打开，增加这个参数，目前小说有用
-  if (!isFromBaidu() && !isMIPCdn()) {
+  if (!isFromBaidu() && !isCacheUrl()) {
     url += '&from=noshell'
   }
   return url

--- a/components/mip-custom/common/url.js
+++ b/components/mip-custom/common/url.js
@@ -123,7 +123,37 @@ const getSourceId = () => {
   }
   return sourceIdArr.join(',')
 }
-
+/**
+ * 当前域名为百度或者 referrer 是百度
+ *
+ * @returns {boolean} 返回布尔值
+ */
+const isFromBaidu = () => {
+  return matchDomain(window.location.href, '.baidu') ||
+    matchDomain(document.referrer, '.baidu')
+}
+/**
+ * 当前域名为 mipcdn
+ *
+ * @returns {boolean} 返回布尔值
+ */
+const isMIPCdn = () => {
+  return matchDomain(window.location.href, '.mipcdn')
+}
+/**
+ * 判断链接是否是某个域名
+ *
+ * @param {string} url 链接
+ * @param {string} domain 某个域名
+ * @returns {boolean} 返回布尔值
+ */
+const matchDomain = (url, domain) => {
+  // 提取 https://(xxx.baidu.com)/ 中的括号里的部分进行判断
+  let match = url.match(/:\/\/([^/]+)/i)
+  if (match) {
+    return match[1].indexOf(domain) !== -1
+  }
+}
 /**
  * [get url 拼接函数]
  *
@@ -156,7 +186,8 @@ const get = (el, poi) => {
   }
 
   // 非mip-shell增加noshell参数
-  if (MIP.standalone) {
+  // 非百度域且不是mip cache链接打开，增加这个参数，目前小说有用
+  if (!isFromBaidu() && !isMIPCdn()) {
     url += '&from=noshell'
   }
   return url


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#663 

**1、升级点** （清晰准确的描述升级的功能点）
mip-custom 在百度域和mipcdn外加参数noshell

**2、影响范围** （描述该需求上线会影响什么功能）
所有mip小说页面，广告正常展现

mip小说传的一个参数 noshell  判断加不加这个参数的方法改了下 其他逻辑没有改动

**3、自测 checklist**
代理线上小说测试，广告展现正常

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



