### PR TITLE
remove percy from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ os:
   - linux
 install:
   - travis_retry npm install
-  - gem install percy-cli
 script:
   - npm run lint
   - npm run site
-  - percy snapshot ./dist/examples/ --enable_javascript
 
 branches:
   only:


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

用于组件截图测试的 percy 服务目前大概率误报，暂时从 travis 集成服务中移除。

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



