### PR TITLE
feat: 新增 mip-action-macro

### DIFF
--- a/components/mip-action-macro/README.md
+++ b/components/mip-action-macro/README.md
@@ -1,0 +1,31 @@
+# mip-action-macro
+
+标题|内容
+----|----
+类型|
+支持布局| nodisplay
+所需脚本| [https://c.mipcdn.com/static/v2/mip-action-macro/mip-action-macro.js](https://c.mipcdn.com/static/v2/mip-action-macro/mip-action-macro.js)
+
+## 说明
+
+组件功能说明
+
+## 示例
+
+示例说明
+
+```
+// 代码示例
+```
+
+## 属性
+
+### 属性1
+
+**说明**：
+
+**必选项**：
+
+**单位**：
+
+**默认值**：

--- a/components/mip-action-macro/example/index.html
+++ b/components/mip-action-macro/example/index.html
@@ -52,7 +52,7 @@
         id="action-without-condition"
         on="execute:MIP.navigateTo(url='https://www.baidu.com?a=' + a, target='_blank')"
       ></mip-action-macro>
-      <button on="tap:action-without-condition.execute">点击跳转至百度首页</button>
+      <button on="tap:action-without-condition.execute">点击后在新页面打开百度首页</button>
     </div>
     <div class="wrapper">
       <h2>测试增加 condition 的情况</h2>
@@ -75,7 +75,7 @@
         on="execute:MIP.navigateTo(url='https://www.baidu.com?a=' + a + '&b=' + event.b, target='_blank');
               mismatch:MIP.navigateTo(url='https://www.baidu.com?a=' + a, target='_top')"
       ></mip-action-macro>
-      <button on="tap:action-with-args.execute(b=123)">打开百度首页 并带上参数 b</button>
+      <button on="tap:action-with-args.execute(b=123)">在新页面打开百度首页 并带上参数 b</button>
     </div>
 
     <script src="https://c.mipcdn.com/static/v2/mip.js"></script>

--- a/components/mip-action-macro/example/index.html
+++ b/components/mip-action-macro/example/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html mip>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1,user-scalable=no">
+    <title>MIP page</title>
+    <link rel="canonical" href="对应的原页面地址">
+    <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
+    <style mip-custom>
+    /* 自定义样式 */
+    </style>
+  </head>
+  <body>
+    <div>
+      <mip-action-macro></mip-action-macro>
+    </div>
+    <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
+    <script src="/mip-action-macro/mip-action-macro.js"></script>
+  </body>
+</html>

--- a/components/mip-action-macro/example/index.html
+++ b/components/mip-action-macro/example/index.html
@@ -8,12 +8,76 @@
     <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
     <style mip-custom>
     /* 自定义样式 */
+    button {
+      border: 1px solid #000;
+      padding: 2px 4px;
+    }
+    .description {
+      margin-bottom: 20px;
+      margin-left: 15px;
+      padding: 15px 5px 5px 5px;
+    }
+    .description ul {
+      list-style-type: circle;
+    }
+
+    .wrapper {
+      margin: 5px;
+      border: 1px solid #000;
+      padding: 5px;
+    }
     </style>
   </head>
   <body>
+    <mip-data>
+      <script type="application/json">
+      {
+        "a": 1,
+        "target": "_blank"
+      }
+      </script>
+    </mip-data>
     <div>
-      <mip-action-macro></mip-action-macro>
+      <div class="description">
+        <p>mip-action-macro 是 MIP 交互机制的补充组件，其作用主要包括：</p>
+        <ul>
+          <li>增加行为表达式的可复用性。开发者可以通过 mip-action-macro 将一些通用的行为进行封装，这样就可以通过 [id].execute 的方式去复用这些行为</li>
+          <li>增加行为执行前的分支判断能力。mip-action-macro 提供了 condition 配置项，在执行方法前，会首先判断 condition 的执行条件是否为 truly，对应触发 execute 或 mismatch 事件，这样监听不同的事件就能够起到分支判断的效果。</li>
+        </ul>
+      </div>
+    <div class="wrapper">
+      <h2>测试正常的 action macro</h2>
+      <p>此时 action macro 未定义 condition，默认触发 execute 行为</p>
+      <mip-action-macro
+        id="action-without-condition"
+        on="execute:MIP.navigateTo(url='https://www.baidu.com?a=' + a, target='_blank')"
+      ></mip-action-macro>
+      <button on="tap:action-without-condition.execute">点击跳转至百度首页</button>
     </div>
+    <div class="wrapper">
+      <h2>测试增加 condition 的情况</h2>
+      <p>通过点击切换 target，在执行 action-with-conditon.execute 时会依次进入不同的事件当中</p>
+      <mip-action-macro
+        id="action-with-condition"
+        condition="target === '_blank'"
+        on="execute:MIP.navigateTo(url='https://www.baidu.com?a=' + a, target='_blank');
+              mismatch:MIP.navigateTo(url='https://www.baidu.com?a=' + a, target='_top')"
+      ></mip-action-macro>
+      <button on="tap:action-with-condition.execute" m-text="'打开百度首页 target：' + target"></button>
+      <button on="tap:MIP.setData({ target: target === '_blank' ? '_top' : '_blank' })">点击切换 target</button>
+    </div>
+    <div class="wrapper">
+      <h2>测试传参</h2>
+      <p>在执行 mip-action-macro 的 execute 事件时，允许传入参数，并在 condition 和 on 表达式里面通过 event.xxx 访问。这里要求参数必须满足 key=value 的参数定义形式。</p>
+      <mip-action-macro
+        id="action-with-args"
+        condition="event.b === 123"
+        on="execute:MIP.navigateTo(url='https://www.baidu.com?a=' + a + '&b=' + event.b, target='_blank');
+              mismatch:MIP.navigateTo(url='https://www.baidu.com?a=' + a, target='_top')"
+      ></mip-action-macro>
+      <button on="tap:action-with-args.execute(b=123)">打开百度首页 并带上参数 b</button>
+    </div>
+
     <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
     <script src="/mip-action-macro/mip-action-macro.js"></script>
   </body>

--- a/components/mip-action-macro/index.less
+++ b/components/mip-action-macro/index.less
@@ -1,0 +1,6 @@
+mip-action-macro {
+  .wrapper {
+    margin: 0 auto;
+    text-align: center;
+  }
+}

--- a/components/mip-action-macro/index.less
+++ b/components/mip-action-macro/index.less
@@ -1,6 +1,0 @@
-mip-action-macro {
-  .wrapper {
-    margin: 0 auto;
-    text-align: center;
-  }
-}

--- a/components/mip-action-macro/mip-action-macro.js
+++ b/components/mip-action-macro/mip-action-macro.js
@@ -6,7 +6,7 @@
 const {
   util: { parse, log },
   CustomElement,
-  viewer: { eventAction }
+  viewer
 } = MIP
 
 const EXECUTE_EVENT = 'execute'
@@ -36,21 +36,33 @@ export default class MIPActionMacro extends CustomElement {
     this.addEventAction(EXECUTE_EVENT, this.execution.bind(this))
   }
 
-  execute (e, params) {
-    let event = EXECUTE_EVENT
+  execution (e, params) {
+    params = params.trim()
+
+    let eventObj
+    if (params !== '') {
+      try {
+        eventObj = JSON.parse(params)
+      } catch (e) {}
+    }
+
+    if (!eventObj) {
+      eventObj = {}
+    }
+
+    let eventName = EXECUTE_EVENT
 
     if (this.fn) {
       let result = this.fn({
-        event: params,
+        event: eventObj,
         // eventName: EXECUTE_EVENT,
         target: this.element
       })
       if (!result) {
-        event = MISMATCH_EVENT
+        eventName = MISMATCH_EVENT
       }
     }
-
-    eventAction.execute(event, this.element, params)
+    viewer.eventAction.execute(eventName, this.element, eventObj)
   }
 
   prerenderAllowed () {

--- a/components/mip-action-macro/mip-action-macro.js
+++ b/components/mip-action-macro/mip-action-macro.js
@@ -1,0 +1,59 @@
+/**
+ * @file mip-action-macro.js
+ * @author clark-t (clarktanglei@163.com)
+ */
+
+const {
+  util: { parse, log },
+  CustomElement,
+  viewer: { eventAction }
+} = MIP
+
+const EXECUTE_EVENT = 'execute'
+const MISMATCH_EVENT = 'mismatch'
+
+const logger = log('mip-action-macro')
+
+export default class MIPActionMacro extends CustomElement {
+  static props = {
+    condition: {
+      type: String,
+      default: ''
+    }
+  }
+
+  build () {
+    const condition = this.props.condition
+
+    if (condition) {
+      try {
+        this.fn = parse(condition, 'Conditional')
+      } catch (e) {
+        logger.error(e)
+      }
+    }
+
+    this.addEventAction(EXECUTE_EVENT, this.execution.bind(this))
+  }
+
+  execute (e, params) {
+    let event = EXECUTE_EVENT
+
+    if (this.fn) {
+      let result = this.fn({
+        event: params,
+        // eventName: EXECUTE_EVENT,
+        target: this.element
+      })
+      if (!result) {
+        event = MISMATCH_EVENT
+      }
+    }
+
+    eventAction.execute(event, this.element, params)
+  }
+
+  prerenderAllowed () {
+    return false
+  }
+}


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
https://github.com/mipengine/mip2/issues/679

依赖 mip2 改动暴露 MIP.util.parse 方法：
https://github.com/mipengine/mip2/pull/698

**1、升级点** （清晰准确的描述升级的功能点）

新增 mip-action-macro

1. 在使用 on 表达式的时候可以通过 mip-action-macro 实现行为复用；
2. 增加 condition，使得行为在执行前可以先通过分支判断来决定是否触发行为；
3. 支持行为传参，通过 [id].execute(arg1=xxx,arg2=xxx) 的方式传入 mip-action-macro 当中，并可以在 condition 表达式和 on 表达式里面通过 event.arg1 event.arg2 访问到参数。

**2、影响范围** （描述该需求上线会影响什么功能）
无

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



