### PR TITLE
fix: 使 template 下可以用 section 等块级元素，已 id 标识

### DIFF
--- a/components/mip-autocomplete/README.md
+++ b/components/mip-autocomplete/README.md
@@ -99,7 +99,7 @@
 
 ### 结合 `mip-mustache` 组件的 `template` 模板渲染组件使用
 
->注意：由于 `mip-form` 不支持在其内部写 `div` 元素，所以 `mip-form` 子节点的 `div` 需要使用 `section`、`menu` 等可用元素替代。同时需要在替代元素上指定 `id="template-element"`。
+>注意：由于 `mip-form` 下的 `div` 元素默认不显示，所以 `mip-form` 的 `div` 需要开发者手动进行 `mip-form div` 样式覆盖或者使用 `section`等可用元素替代。同时在 `template` 下的元素都会被模板渲染，注意不要添加无关元素。
 
 ```html
 <p>使用 filter-value 属性进行筛选，同时使用 template 模板渲染</p>
@@ -129,7 +129,7 @@
     </script>
     <template type="mip-mustache"
       id="mip-template-custom">
-      <section class="city-item" id="template-element"
+      <section class="city-item"
         data-value="{{city}}, {{province}}">
         <section>{{city}}, {{province}}</section>
         <section class="custom-population">点赞数: {{population}}</section>

--- a/components/mip-autocomplete/README.md
+++ b/components/mip-autocomplete/README.md
@@ -99,6 +99,8 @@
 
 ### 结合 `mip-mustache` 组件的 `template` 模板渲染组件使用
 
+>注意：由于 `mip-form` 不支持在其内部写 `div` 元素，所以 `mip-form` 子节点的 `div` 需要使用 `section`、`menu` 等可用元素替代。同时需要在替代元素上指定 `id="template-element"`。
+
 ```html
 <p>使用 filter-value 属性进行筛选，同时使用 template 模板渲染</p>
 <mip-form url="https://path/to/your/api">
@@ -127,7 +129,7 @@
     </script>
     <template type="mip-mustache"
       id="mip-template-custom">
-      <section class="city-item"
+      <section class="city-item" id="template-element"
         data-value="{{city}}, {{province}}">
         <section>{{city}}, {{province}}</section>
         <section class="custom-population">点赞数: {{population}}</section>

--- a/components/mip-autocomplete/example/mip-autocomplete.html
+++ b/components/mip-autocomplete/example/mip-autocomplete.html
@@ -158,7 +158,7 @@
       </script>
       <template type="mip-mustache"
         id="mip-template-custom">
-        <section class="city-item" id="template-element"
+        <section class="city-item"
           data-value="{{city}}, {{province}}">
           <section>{{city}}, {{province}}</section>
           <section class="custom-population">点赞数: {{population}}</section>

--- a/components/mip-autocomplete/example/mip-autocomplete.html
+++ b/components/mip-autocomplete/example/mip-autocomplete.html
@@ -158,7 +158,7 @@
       </script>
       <template type="mip-mustache"
         id="mip-template-custom">
-        <section class="city-item"
+        <section class="city-item" id="template-element"
           data-value="{{city}}, {{province}}">
           <section>{{city}}, {{province}}</section>
           <section class="custom-population">点赞数: {{population}}</section>

--- a/components/mip-autocomplete/mip-autocomplete.ts
+++ b/components/mip-autocomplete/mip-autocomplete.ts
@@ -409,7 +409,7 @@ export default class MIPAutocomplete extends CustomElement {
         renderedChildren.map((child: any) => {
           const parserEle = document.createElement('div')
           parserEle.innerHTML = child
-          const childEle = parserEle.querySelector('section')
+          const childEle = parserEle.querySelector('#template-element')
           if (!childEle) {
             return
           }

--- a/components/mip-autocomplete/mip-autocomplete.ts
+++ b/components/mip-autocomplete/mip-autocomplete.ts
@@ -409,7 +409,7 @@ export default class MIPAutocomplete extends CustomElement {
         renderedChildren.map((child: any) => {
           const parserEle = document.createElement('div')
           parserEle.innerHTML = child
-          const childEle = parserEle.querySelector('#template-element')
+          const childEle = parserEle.children[0]
           if (!childEle) {
             return
           }


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）
使 template 下可以只用 menu 等块级元素
**2、影响范围** （描述该需求上线会影响什么功能）
暂无影响
**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



