### PR TITLE
修复 mip-accordion 在刷新时丢失标题显示状态

### DIFF
--- a/components/mip-accordion/example/mip-accordion-manual.html
+++ b/components/mip-accordion/example/mip-accordion-manual.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html mip>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>MIP page</title>
+    <link rel="canonical" href="对应的原页面地址">
+    <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
+    <style mip-custom>
+      h4{
+        margin: 5px 10px;
+        background: #90ed90;
+      }
+      p{
+        margin: 0 10px;
+      }
+    /* 自定义样式 */
+    </style>
+  </head>
+  <body>
+  <mip-accordion type="manual" animatetime="0.24" sessions-key="test">
+    <section>
+      <h4>下拉第一个</h4>
+      <p class="mip-accordion-content">我说你是人间的四月天；笑声点亮了四面风；轻灵在春的光艳中交舞着变。你是四月早天里的云烟，黄昏吹着风的软，星子在无意中闪，</p>
+    </section>
+    <section  expanded="open">
+      <h4>下拉第二个</h4>
+      <p>细雨点洒在花前。那轻，那娉婷，你是，鲜妍百花的冠冕你戴着，你是天真，庄严，你是夜夜的月圆。</p>
+    </section>
+    <section>
+      <h4>下拉第三个</h4>
+      <mip-img layout="responsive" width="400" height="200" src="https://www.mipengine.org/static/img/sample_01.jpg" class="mip-accordion-content"></mip-img>
+    </section>
+  </mip-accordion>
+    <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
+    <script src="/mip-accordion/mip-accordion.js"></script>
+  </body>
+</html>

--- a/components/mip-accordion/example/mip-accordion-title.html
+++ b/components/mip-accordion/example/mip-accordion-title.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html mip>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>MIP page</title>
+    <link rel="canonical" href="对应的原页面地址">
+    <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
+    <style mip-custom>
+      h4{
+        margin: 5px 10px;
+        background: #90ed90;
+      }
+      p{
+        margin: 0 10px;
+      }
+    /* 自定义样式 */
+    </style>
+  </head>
+  <body>
+  <mip-accordion animatetime='0.24' sessions-key="ceshi_10086">
+    <section>
+      <h4>下拉第一个</h4>
+      <p class="mip-accordion-content">我说你是人间的四月天；笑声点亮了四面风；轻灵在春的光艳中交舞着变。你是四月早天里的云烟，黄昏吹着风的软，星子在无意中闪，</p>
+    </section>
+    <section expanded="open">
+      <h4>
+        <div class="show-more">显示更多</div>
+        <div class="show-less">折叠</div>
+      </h4>
+      <div>
+        <div>次级内容</div>
+        <section>
+          <h4>
+            <div class="show-more">显示更多</div>
+            <div class="show-less">折叠</div>
+          </h4>
+          <div>
+            <p>细雨点洒在花前。那轻，那娉婷，你是，鲜妍百花的冠冕你戴着，你是天真，庄严，你是夜夜的月圆。</p>
+          </div>
+        </section>
+      </div>
+    </section>
+    <section>
+      <h4>下拉第三个</h4>
+      <mip-img layout="responsive" width="400" height="200" src="https://www.mipengine.org/static/img/sample_01.jpg" class="mip-accordion-content"></mip-img>
+    </section>
+  </mip-accordion>
+    <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
+    <script src="/mip-accordion/mip-accordion.js"></script>
+  </body>
+</html>

--- a/components/mip-accordion/mip-accordion.js
+++ b/components/mip-accordion/mip-accordion.js
@@ -179,10 +179,22 @@ function getSections (element) {
   return validSections
 }
 
+/**
+ * 生成 session key
+ *
+ * @param {string} sessionId sessionId
+ * @return {string} session key
+ */
 function getSessionKey (sessionId) {
   return `MIP-${sessionId}-${location.href}`
 }
 
+/**
+ * 处理动画时间
+ *
+ * @param {string} aniTimeAttr 动画时间配置属性
+ * @return {number} 动画时间秒数
+ */
 function getAniTime (aniTimeAttr) {
   return isNaN(aniTimeAttr) ? 0.24 : Math.min(parseFloat(aniTimeAttr, 10), 1)
 }

--- a/components/mip-accordion/mip-accordion.less
+++ b/components/mip-accordion/mip-accordion.less
@@ -2,25 +2,35 @@ mip-accordion {
   .mip-accordion-content {
     display: none !important;
     overflow: hidden;
+
+    &[aria-expanded=open] {
+      display: block !important;
+    }
   }
 
-  section .show-more {
-    display: block;
-  }
+  section {
+    .show-more {
+      display: block;
+    }
 
-  section[expanded=open] .show-more {
-    display: none !important;
-  }
+    .show-less {
+      display: none;
+    }
 
-  .mip-accordion-content[aria-expanded="open"] {
-    display: block !important;
-  }
+    &[expanded=open] {
+      > :first-child {
+        .show-more {
+          display: none !important;
+        }
 
-  section .show-less {
-    display: none;
-  }
+        .show-less {
+          display: block !important;
+        }
+      }
 
-  section[expanded=open] .show-less {
-    display: block;
+      > :nth-child(2) {
+        display: block !important;
+      }
+    }
   }
 }


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#710 

**1、升级点** （清晰准确的描述升级的功能点）
1. 将 mip-accordion 的状态维护统一交给 section 的来控制，并且直接由 css 进行相关节点的隐藏展现
2. 保持现有的属性不变

**2、影响范围** （描述该需求上线会影响什么功能）
1. mip-accordion 在 header 设置了 .show-more 和 .show-less 的状态下

**3、自测 checklist**
1. bug 修复
2. mip 官网的所有的示例全部展示正常
3. 组件自带 examples 显示正常
4. 新增了 example 来覆盖在 section 嵌套的情形下标题是否能显示正常

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



