### PR TITLE
修复 mip-accordion 在刷新时丢失标题显示状态

### DIFF
--- a/components/mip-accordion/example/mip-accordion-manual.html
+++ b/components/mip-accordion/example/mip-accordion-manual.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html mip>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>MIP page</title>
+    <link rel="canonical" href="对应的原页面地址">
+    <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
+    <style mip-custom>
+      h4{
+        margin: 5px 10px;
+        background: #90ed90;
+      }
+      p{
+        margin: 0 10px;
+      }
+    /* 自定义样式 */
+    </style>
+  </head>
+  <body>
+  <mip-accordion type="manual" animatetime="0.24" sessions-key="test">
+    <section>
+      <h4>下拉第一个</h4>
+      <p class="mip-accordion-content">我说你是人间的四月天；笑声点亮了四面风；轻灵在春的光艳中交舞着变。你是四月早天里的云烟，黄昏吹着风的软，星子在无意中闪，</p>
+    </section>
+    <section  expanded="open">
+      <h4>下拉第二个</h4>
+      <p>细雨点洒在花前。那轻，那娉婷，你是，鲜妍百花的冠冕你戴着，你是天真，庄严，你是夜夜的月圆。</p>
+    </section>
+    <section>
+      <h4>下拉第三个</h4>
+      <mip-img layout="responsive" width="400" height="200" src="https://www.mipengine.org/static/img/sample_01.jpg" class="mip-accordion-content"></mip-img>
+    </section>
+  </mip-accordion>
+    <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
+    <script src="/mip-accordion/mip-accordion.js"></script>
+  </body>
+</html>

--- a/components/mip-accordion/example/mip-accordion-title.html
+++ b/components/mip-accordion/example/mip-accordion-title.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html mip>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>MIP page</title>
+    <link rel="canonical" href="对应的原页面地址">
+    <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
+    <style mip-custom>
+      h4{
+        margin: 5px 10px;
+        background: #90ed90;
+      }
+      p{
+        margin: 0 10px;
+      }
+    /* 自定义样式 */
+    </style>
+  </head>
+  <body>
+  <mip-accordion animatetime='0.24' sessions-key="ceshi_10086">
+    <section>
+      <h4>下拉第一个</h4>
+      <p class="mip-accordion-content">我说你是人间的四月天；笑声点亮了四面风；轻灵在春的光艳中交舞着变。你是四月早天里的云烟，黄昏吹着风的软，星子在无意中闪，</p>
+    </section>
+    <section expanded="open">
+      <h4>
+        <div class="show-more">显示更多</div>
+        <div class="show-less">折叠</div>
+      </h4>
+      <div>
+        <div>次级内容</div>
+        <section>
+          <h4>
+            <div class="show-more">显示更多</div>
+            <div class="show-less">折叠</div>
+          </h4>
+          <div>
+            <p>细雨点洒在花前。那轻，那娉婷，你是，鲜妍百花的冠冕你戴着，你是天真，庄严，你是夜夜的月圆。</p>
+          </div>
+        </section>
+      </div>
+    </section>
+    <section>
+      <h4>下拉第三个</h4>
+      <mip-img layout="responsive" width="400" height="200" src="https://www.mipengine.org/static/img/sample_01.jpg" class="mip-accordion-content"></mip-img>
+    </section>
+  </mip-accordion>
+    <script src="https://c.mipcdn.com/static/v2/mip.js"></script>
+    <script src="/mip-accordion/mip-accordion.js"></script>
+  </body>
+</html>

--- a/components/mip-accordion/mip-accordion.js
+++ b/components/mip-accordion/mip-accordion.js
@@ -196,7 +196,8 @@ function getSessionKey (sessionId) {
  * @returns {number} 动画时间秒数
  */
 function getAniTime (aniTimeAttr) {
-  return isNaN(aniTimeAttr) ? 0.24 : Math.min(parseFloat(aniTimeAttr, 10), 1)
+  let time = parseFloat(aniTimeAttr, 10)
+  return isNaN(time) ? 0.24 : Math.min(time, 1)
 }
 
 export default class MIPAccordion extends CustomElement {

--- a/components/mip-accordion/mip-accordion.js
+++ b/components/mip-accordion/mip-accordion.js
@@ -157,7 +157,7 @@ function heightAni (opt) {
  * 获取组件 slot 下面的所有 <section>，并且过滤掉嵌套 MIP 组件下面的 section，以免 MIP 组件嵌套造成相互影响
  *
  * @param {HTMLElement} element 组件根节点
- * @return {Array.<HTMLElement>} selection 列表
+ * @returns {Array.<HTMLElement>} selection 列表
  */
 function getSections (element) {
   const sections = element.querySelectorAll('section')
@@ -183,7 +183,7 @@ function getSections (element) {
  * 生成 session key
  *
  * @param {string} sessionId sessionId
- * @return {string} session key
+ * @returns {string} session key
  */
 function getSessionKey (sessionId) {
   return `MIP-${sessionId}-${location.href}`
@@ -193,7 +193,7 @@ function getSessionKey (sessionId) {
  * 处理动画时间
  *
  * @param {string} aniTimeAttr 动画时间配置属性
- * @return {number} 动画时间秒数
+ * @returns {number} 动画时间秒数
  */
 function getAniTime (aniTimeAttr) {
   return isNaN(aniTimeAttr) ? 0.24 : Math.min(parseFloat(aniTimeAttr, 10), 1)
@@ -329,7 +329,7 @@ export default class MIPAccordion extends CustomElement {
    * 通过节点容器获取 header
    *
    * @param {HTMLElement} section 节点容器
-   * @return {HTMLElement} header
+   * @returns {HTMLElement} header
    */
   getHeader (section) {
     return section.children.item(0)
@@ -339,7 +339,7 @@ export default class MIPAccordion extends CustomElement {
    * 通过节点容器获取 content
    *
    * @param {HTMLElement} section 节点容器
-   * @return {HTMLElement} content
+   * @returns {HTMLElement} content
    */
   getContent (section) {
     return section.children.item(1)
@@ -349,7 +349,7 @@ export default class MIPAccordion extends CustomElement {
    * 展开节点
    *
    * @param {string=} targetId content 的节点 id
-   * @param {HTMLElement} content 节点容器
+   * @param {HTMLElement} section 节点容器
    * @param {boolean} animate 展开过程是否出动画
    */
   unfold ({
@@ -392,7 +392,7 @@ export default class MIPAccordion extends CustomElement {
    * 折叠节点
    *
    * @param {string=} targetId content 的节点 id
-   * @param {HTMLElement} content 节点容器
+   * @param {HTMLElement} section 节点容器
    * @param {boolean} animate 展开过程是否出动画
    */
   fold ({

--- a/components/mip-accordion/mip-accordion.js
+++ b/components/mip-accordion/mip-accordion.js
@@ -64,7 +64,7 @@ const OPEN_STATUS = 'open'
  * @constant
  * @type {string}
  */
-const CLOSE_STATUS = 'close'
+// const CLOSE_STATUS = 'close'
 
 /**
  * 设置 session storage 缓存
@@ -108,7 +108,7 @@ function getSession (key) {
  *   "transitionTime": "0.3",         // seconds, animation time
  *   "tarHeight": "140px",            // DOM height when animation ends
  *   "oriHeight": "20px",             // DOM height when animation begins
- *   "cbFun": function() {}.bind()  //callback, exec after animation
+ *   "cb": function() {}.bind()  //callback, exec after animation
  * }
  */
 function heightAni (opt) {
@@ -119,10 +119,10 @@ function heightAni (opt) {
     return
   }
 
-  let transitionTime = isNaN(opt.transitionTime) ? 0.24 : Math.min(parseFloat(opt.transitionTime), 1)
+  let transitionTime = opt.transitionTime
   let oriHeight = (opt.oriHeight !== undefined ? opt.oriHeight : getComputedStyle(element).height)
   let tarHeight
-  let cbFun = opt.cbFun || function () {}
+  let cb = opt.cb || function () {}
 
   if (type === 'unfold') {
     if (opt.tarHeight !== undefined) {
@@ -150,23 +150,8 @@ function heightAni (opt) {
   }, 10)
 
   // 动画结束后，执行 callback
-  setTimeout(cbFun, transitionTime * 1000)
+  setTimeout(cb, transitionTime * 1000)
 }
-
-// /**
-//  * 获取元素的兄弟节点
-//  *
-//  * @param   {HTMLElement} el  源 DOM 元素
-//  * @returns {HTMLElement}  目标 DOM 元素
-//  */
-// function getSibling (el) {
-//   el = el.nextSibling
-//   while (el.nodeType === 3) {
-//     el = el.nextSibling
-//   }
-
-//   return el
-// }
 
 /**
  * 获取组件 slot 下面的所有 <section>，并且过滤掉嵌套 MIP 组件下面的 section，以免 MIP 组件嵌套造成相互影响
@@ -194,7 +179,37 @@ function getSections (element) {
   return validSections
 }
 
+/**
+ * 生成 session key
+ *
+ * @param {string} sessionId sessionId
+ * @return {string} session key
+ */
+function getSessionKey (sessionId) {
+  return `MIP-${sessionId}-${location.href}`
+}
+
+/**
+ * 处理动画时间
+ *
+ * @param {string} aniTimeAttr 动画时间配置属性
+ * @return {number} 动画时间秒数
+ */
+function getAniTime (aniTimeAttr) {
+  return isNaN(aniTimeAttr) ? 0.24 : Math.min(parseFloat(aniTimeAttr, 10), 1)
+}
+
 export default class MIPAccordion extends CustomElement {
+  constructor (...args) {
+    super(...args)
+
+    this.type = ''
+    this.sections = null
+    this.sessionKey = ''
+    this.aniTime = 0.24
+    this.expandedLimit = false
+  }
+
   /**
    * 允许预渲染
    */
@@ -202,188 +217,215 @@ export default class MIPAccordion extends CustomElement {
     return true
   }
 
-  /**
-   * 组件渲染
-   */
   build () {
-    let element = this.element
-    let type = element.getAttribute('type') || 'automatic'
-    let sections = this.sections = getSections(element)
-    let sessionId = this.sessionId = element.getAttribute('sessions-key')
-    let sessionKey = this.sessionKey = `MIP-${sessionId}-${location.href}`
-    let currentState = getSession.apply(this)
+    // 初始化属性
+    this.type = this.element.getAttribute('type') || 'automatic'
+    this.sections = getSections(this.element)
+    this.sessionId = this.element.getAttribute('sessions-key')
+    this.sessionKey = getSessionKey(this.sessionId)
 
-    element.setAttribute('role', 'tablist')
+    this.aniTime = getAniTime(this.element.getAttribute('animatetime'))
+    this.expandedLimit = this.element.hasAttribute('expanded-limit')
 
-    sections.forEach((section, index) => {
+    this.element.setAttribute('role', 'tablist')
+
+    // 初始化节点属性，绑定事件
+    this.sections.forEach((section, index) => {
       // let header = section.querySelector('[accordionbtn]')
       // let content = section.querySelector('[accordionbox]')
-
-      let header = section.children.item(0)
-      let content = section.children.item(1)
-      header && header.classList.add(MIP_ACCORDION_HEADER_CLASS)
-      content && content.classList.add(MIP_ACCORDION_CONTENT_CLASS)
-
-      let contentId = content.getAttribute('id')
-      if (!contentId) {
-        contentId = `MIP_${sessionId}_content_${index}`
-        content.setAttribute('id', contentId)
-      }
-
-      // tab 状态 [展开/收起] 判断
-      if (currentState[contentId]) {
-        section.setAttribute(EXPANDED_ATTRIBUTE, '')
-      } else if (currentState[contentId] === false) {
-        section.removeAttribute(EXPANDED_ATTRIBUTE)
-      }
-
-      // 手动控制或者自动根据用户操作控制
-      if (type === 'manual' && section.hasAttribute(EXPANDED_ATTRIBUTE)) {
-        content.setAttribute(ARIA_EXPANDED_ATTRIBUTE, OPEN_STATUS)
-        setSession(sessionKey, element.getAttribute(ARIA_CONTROLS_ATTRIBUTE), true)
-      } else if (type === 'automatic') {
-        content.setAttribute(ARIA_EXPANDED_ATTRIBUTE, section.hasAttribute(EXPANDED_ATTRIBUTE).toString())
-      }
-
-      header.setAttribute(ARIA_CONTROLS_ATTRIBUTE, contentId)
+      this.initAttr(section, index)
+      this.bindEvent(section)
     })
-
-    if (type === 'automatic') {
-      this.userSelect()
-    }
-
-    this.bindEvents()
   }
 
   /**
-   * 恢复用户上次的选择
+   * 初始化 accordion 节点属性
+   *
+   * @param {HTMLElement} section 容器
+   * @param {number} index section 在全文的序号
    */
-  userSelect () {
-    let ele = this.element
-    let sessionData = getSession(this.sessionKey)
+  initAttr (section, index) {
+    let header = this.getHeader(section)
+    let content = this.getContent(section)
 
-    for (let prop in sessionData) {
-      if (!sessionData.hasOwnProperty(prop)) {
-        return
-      }
+    // 添加默认样式
+    header && header.classList.add(MIP_ACCORDION_HEADER_CLASS)
+    content && content.classList.add(MIP_ACCORDION_CONTENT_CLASS)
 
-      if (sessionData[prop]) {
-        let content = ele.querySelector('#' + prop)
-        content.setAttribute(ARIA_EXPANDED_ATTRIBUTE, OPEN_STATUS)
-        let parent = content.parentNode
-        while (parent !== ele) {
-          if (parent.tagName === 'section') {
-            parent.setAttribute(EXPANDED_ATTRIBUTE, OPEN_STATUS)
-          }
-          parent = parent.parentNode
-        }
-        // ele.querySelector('section').setAttribute(EXPANDED_ATTRIBUTE, OPEN_STATUS)
+    // 设置内容块 id
+    let contentId = content.getAttribute('id')
+
+    if (!contentId) {
+      contentId = `MIP_${this.sessionId}_content_${index}`
+      content.setAttribute('id', contentId)
+    }
+
+    header.setAttribute(ARIA_CONTROLS_ATTRIBUTE, contentId)
+
+    // 根据组件配置和 session 状态初始化节点的展开和折叠
+    let sectionDesc = {
+      section,
+      contentId,
+      animate: false
+    }
+
+    // 手动控制或者自动根据用户操作控制
+    if (this.type === 'manual' && section.hasAttribute(EXPANDED_ATTRIBUTE)) {
+      this.unfold(sectionDesc)
+    } else if (this.type === 'automatic') {
+      this.currentState = this.currentState || getSession(this.sessionKey)
+
+      if (this.currentState[contentId]) {
+        this.unfold(sectionDesc)
+      } else if (this.currentState[contentId] === false) {
+        this.fold(sectionDesc)
       }
     }
   }
 
   /**
    * 绑定事件
+   *
+   * @param {HTMLElement} section 节点容器
    */
-  bindEvents () {
-    let element = this.element
-    let sessionKey = this.sessionKey
-    let sections = this.sections
-    let aniTimeAttr = element.getAttribute('animatetime')
-    let aniTime = isNaN(aniTimeAttr) ? 0.24 : Math.min(parseFloat(aniTimeAttr, 10), 1)
+  bindEvent (section) {
+    let header = this.getHeader(section)
+    let targetId = header.getAttribute(ARIA_CONTROLS_ATTRIBUTE)
 
-    sections.map(section => section.children.item(0)).forEach(accordionHeader => {
-      accordionHeader.addEventListener('click', function () {
-        let targetId = accordionHeader.getAttribute(ARIA_CONTROLS_ATTRIBUTE)
-        let targetContent = element.querySelector('#' + targetId)
-        let expanded = targetContent.getAttribute(ARIA_EXPANDED_ATTRIBUTE)
+    header.addEventListener('click', () => {
+      let expanded = section.getAttribute(EXPANDED_ATTRIBUTE)
 
-        let section = accordionHeader.parentNode
-        let showMore = section.querySelector('.show-more')
-        let showLess = section.querySelector('.show-less')
+      if (expanded === OPEN_STATUS) {
+        this.fold({
+          section,
+          targetId
+        })
+        return
+      }
 
-        if (expanded === OPEN_STATUS) {
-          // 收起内容区域
-          heightAni({
-            ele: targetContent,
-            type: 'fold',
-            transitionTime: aniTime,
-            cbFun: function () {
-              targetContent.setAttribute(ARIA_EXPANDED_ATTRIBUTE, CLOSE_STATUS)
-            }// .bind(undefined, targetContent)
-          })
-
-          section.removeAttribute(EXPANDED_ATTRIBUTE)
-          if (showMore && showLess) {
-            util.css(showMore, 'display', 'block')
-            util.css(showLess, 'display', 'none')
-          }
-
-          // sections.forEach(section => {
-          //   let showMore = section.querySelector('.show-more')
-          //   let showLess = section.querySelector('.show-less')
-          //   section.classList.remove(EXPANDED_ATTRIBUTE)
-          //   if (showMore && showLess) {
-          //     util.css(showMore, 'display', 'block')
-          //     util.css(showLess, 'display', 'none')
-          //   }
-          // })
-
-          setSession(sessionKey, targetId, false)
-        } else {
-          // 同时只能展开一个节点
-          if (element.hasAttribute('expaned-limit')) {
-            sections.forEach(section => {
-              let content = section.querySelector(`.${MIP_ACCORDION_CONTENT_CLASS}`)
-              let header = section.querySelector(`.${MIP_ACCORDION_HEADER_CLASS}`)
-              let id = header.getAttribute(ARIA_CONTROLS_ATTRIBUTE)
-
-              section.removeAttribute(EXPANDED_ATTRIBUTE)
-              content.removeAttribute(ARIA_EXPANDED_ATTRIBUTE)
-              setSession(sessionKey, id, false)
-
-              heightAni({
-                ele: content,
-                type: 'fold',
-                transitionTime: aniTime,
-                cb: function () {
-                  util.css(content, 'height', '')
-                }
-              })
+      // 同时只能展开一个节点
+      if (this.expandedLimit) {
+        // 折叠其他节点
+        this.sections
+          .filter(otherSection => (
+            otherSection !== section &&
+            otherSection.hasAttribute(EXPANDED_ATTRIBUTE)
+          ))
+          .forEach(otherSection => {
+            this.fold({
+              section: otherSection
             })
-          }
-
-          targetContent.setAttribute(ARIA_EXPANDED_ATTRIBUTE, OPEN_STATUS)
-          section.setAttribute(EXPANDED_ATTRIBUTE, OPEN_STATUS)
-          if (showMore && showLess) {
-            util.css(showLess, 'display', 'block')
-            util.css(showMore, 'display', 'none')
-          }
-
-          // sections.forEach(section => {
-          //   let showMore = section.querySelector('.show-more')
-          //   let showLess = section.querySelector('.show-less')
-          //   section.setAttribute(EXPANDED_ATTRIBUTE, OPEN_STATUS)
-          //   if (showMore && showLess) {
-          //     util.css(showLess, 'display', 'block')
-          //     util.css(showMore, 'display', 'none')
-          //   }
-          // })
-
-          // unfold animation
-          heightAni({
-            ele: targetContent,
-            type: 'unfold',
-            oriHeight: 0,
-            transitionTime: aniTime,
-            cb: function () {
-              util.css(targetContent, 'height', '')
-            }
           })
+      }
 
-          setSession(sessionKey, targetId, true)
-        }
+      this.unfold({
+        section,
+        targetId
       })
     })
+  }
+
+  /**
+   * 通过节点容器获取 header
+   *
+   * @param {HTMLElement} section 节点容器
+   * @return {HTMLElement} header
+   */
+  getHeader (section) {
+    return section.children.item(0)
+  }
+
+  /**
+   * 通过节点容器获取 content
+   *
+   * @param {HTMLElement} section 节点容器
+   * @return {HTMLElement} content
+   */
+  getContent (section) {
+    return section.children.item(1)
+  }
+
+  /**
+   * 展开节点
+   *
+   * @param {string=} targetId content 的节点 id
+   * @param {HTMLElement} content 节点容器
+   * @param {boolean} animate 展开过程是否出动画
+   */
+  unfold ({
+    targetId,
+    section,
+    animate = true
+  }) {
+    section.setAttribute(EXPANDED_ATTRIBUTE, OPEN_STATUS)
+
+    let content = this.getContent(section)
+    if (!content) {
+      return
+    }
+
+    content.setAttribute(ARIA_EXPANDED_ATTRIBUTE, OPEN_STATUS)
+
+    // 记录折叠情况
+    if (this.type === 'automatic') {
+      targetId = targetId || content.getAttribute('id')
+      setSession(this.sessionKey, targetId, true)
+    }
+
+    // 折叠过程是否出动画效果
+    if (!animate) {
+      return
+    }
+
+    heightAni({
+      ele: content,
+      type: 'unfold',
+      oriHeight: 0,
+      transitionTime: this.aniTime,
+      cb () {
+        util.css(content, 'height', '')
+      }
+    })
+  }
+
+  /**
+   * 折叠节点
+   *
+   * @param {string=} targetId content 的节点 id
+   * @param {HTMLElement} content 节点容器
+   * @param {boolean} animate 展开过程是否出动画
+   */
+  fold ({
+    section,
+    targetId,
+    animate = true
+  }) {
+    section.removeAttribute(EXPANDED_ATTRIBUTE)
+
+    let content = this.getContent(section)
+    if (!content) {
+      return
+    }
+
+    // 记录折叠情况
+    if (this.type === 'automatic') {
+      targetId = targetId || content.getAttribute('id')
+      setSession(this.sessionKey, targetId, false)
+    }
+
+    // 折叠过程是否出动画效果
+    if (animate) {
+      // 收起内容区域
+      heightAni({
+        ele: content,
+        type: 'fold',
+        transitionTime: this.aniTime,
+        cb () {
+          content.removeAttribute(ARIA_EXPANDED_ATTRIBUTE)
+        }
+      })
+    } else {
+      content.removeAttribute(ARIA_EXPANDED_ATTRIBUTE)
+    }
   }
 }

--- a/components/mip-accordion/mip-accordion.less
+++ b/components/mip-accordion/mip-accordion.less
@@ -2,25 +2,35 @@ mip-accordion {
   .mip-accordion-content {
     display: none !important;
     overflow: hidden;
+
+    &[aria-expanded=open] {
+      display: block !important;
+    }
   }
 
-  section .show-more {
-    display: block;
-  }
+  section {
+    .show-more {
+      display: block;
+    }
 
-  section[expanded=open] .show-more {
-    display: none !important;
-  }
+    .show-less {
+      display: none;
+    }
 
-  .mip-accordion-content[aria-expanded="open"] {
-    display: block !important;
-  }
+    &[expanded=open] {
+      > :first-child {
+        .show-more {
+          display: none !important;
+        }
 
-  section .show-less {
-    display: none;
-  }
+        .show-less {
+          display: block !important;
+        }
+      }
 
-  section[expanded=open] .show-less {
-    display: block;
+      > :nth-child(2) {
+        display: block !important;
+      }
+    }
   }
 }


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#710 

**1、升级点** （清晰准确的描述升级的功能点）
1. 将 mip-accordion 的状态维护统一交给 section 的来控制，并且直接由 css 进行相关节点的隐藏展现
2. 保持现有的属性不变

**2、影响范围** （描述该需求上线会影响什么功能）
1. mip-accordion 在 header 设置了 .show-more 和 .show-less 的状态下

**3、自测 checklist**
1. bug 修复
2. mip 官网的所有的示例全部展示正常
3. 组件自带 examples 显示正常
4. 新增了 example 来覆盖在 section 嵌套的情形下标题是否能显示正常

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百

