### PR TITLE
修复 mip-toast 和 mip-sticky-ad

### DIFF
--- a/components/mip-sticky-ad/mip-sticky-ad.js
+++ b/components/mip-sticky-ad/mip-sticky-ad.js
@@ -65,6 +65,14 @@ export default class MIPStickyAd extends MIP.CustomElement {
     setTimeout(() => {
       viewport.on('scroll', this.show)
     })
+
+    this.handleHidePage = this.handleHidePage.bind(this)
+    // 切换页面时要还原 body bottom，这里直接关闭组件
+    window.addEventListener('hide-page', this.handleHidePage)
+  }
+
+  handleHidePage () {
+    this.close()
   }
 
   close () {
@@ -115,6 +123,7 @@ export default class MIPStickyAd extends MIP.CustomElement {
 
   disconnectedCallback () {
     viewport.off('scroll', this.show)
+    window.removeEventListener(this.handleHidePage)
     updatePaddingBottom(0)
   }
 }

--- a/components/mip-toast/README.md
+++ b/components/mip-toast/README.md
@@ -17,7 +17,7 @@
 1、弹出框 只弹出文字（不传 info-icon-src）
 
 ```html
-<button on="tap:demo.show">打开 toast</button>
+<button on="tap:demo.showToast">打开 toast</button>
 <mip-toast
   id= "demo"
   info-text="默认提示框"
@@ -29,7 +29,7 @@
 2、弹出框 弹出带图和文字
 
 ```html
-<button on="tap:demo.show">打开 toast</button>
+<button on="tap:demo.showToast">打开 toast</button>
 <mip-toast
   id= "demo"
   info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
@@ -93,12 +93,27 @@
 
 默认值：3
 
-## 接收事件
+## 暴露方法
 
-### show/hidden
+### showToast/hidden
 
-每次其他组件触发抛出事件后，触发 `mip-toast` 的 `show` 事件，并传当前状态是显示
+可以通过 showToast/hidden 方法来显示/隐藏 mip-toast，其中 showToast 的参数接受字段 `infoText`、`infoIconSrc`、`station`、`closeTime`，用来覆盖实际显示的 toast 属性，如果某字段缺失，则使用 mip-toast 的属性。使用示例如下：
 
-注意，每次其他组件触发抛出事件后，也可以触发 `mip-toast` 的 `hidden` 事件，并传当前状态是隐藏
+```html
+<button on="tap:demo.showToast({
+    station: 'bottom',
+    infoText: 'new info text',
+    closeTime: 3,
+    infoIconSrc: 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg'
+})">打开 toast</button>
+<mip-toast
+    id="demo"
+    info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
+    info-text="默认提示框文字Top+图片"
+    station="top"
+    close-time="1"
+>
+</mip-toast>
+```
 
-组件间通信请看文档 https://www.mipengine.org/doc/3-widget/6-help/3-mip-normal.html
+组件间通信请看文档 https://www.mipengine.org/v2/docs/interactive-mip/introduction.html

--- a/components/mip-toast/example/mip-toast1.html
+++ b/components/mip-toast/example/mip-toast1.html
@@ -22,13 +22,12 @@
 </head>
 <body>
   <div>
-    <button on="tap:demo.show">打开 toast</button>
+    <button on="tap:demo.showToast">打开 toast</button>
     <mip-toast
       id="demo"
       info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
       info-text="默认提示框文字Top+图片"
       station="top"
-      auto-close="true"
       close-time="1"
     >
     </mip-toast>

--- a/components/mip-toast/example/mip-toast2.html
+++ b/components/mip-toast/example/mip-toast2.html
@@ -22,13 +22,12 @@
 </head>
 <body>
   <div>
-    <button on="tap:demo.show">打开 toast</button>
+    <button on="tap:demo.showToast">打开 toast</button>
     <mip-toast
       id="demo"
       info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
       info-text="默认提示框文字Center+图片"
       station="center"
-      auto-close="true"
       close-time="2"
     >
     </mip-toast>

--- a/components/mip-toast/example/mip-toast3.html
+++ b/components/mip-toast/example/mip-toast3.html
@@ -22,13 +22,12 @@
 </head>
 <body>
   <div>
-    <button on="tap:demo.show">打开 toast</button>
+    <button on="tap:demo.showToast">打开 toast</button>
     <mip-toast
       id="demo"
       info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
       info-text="默认提示框文字Bottom+图片"
       station="bottom"
-      auto-close="true"
       close-time="2"
     >
     </mip-toast>

--- a/components/mip-toast/example/mip-toast4.html
+++ b/components/mip-toast/example/mip-toast4.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <title>toast 组件</title>
+  <title>MIP page</title>
   <link rel="canonical" href="对应的原页面地址">
   <link rel="stylesheet" href="https://c.mipcdn.com/static/v2/mip.css">
   <style mip-custom>
@@ -22,12 +22,18 @@
 </head>
 <body>
   <div>
-    <button on="tap:demo.showToast">打开 toast</button>
+    <button on="tap:demo.showToast({
+        station: 'bottom',
+        infoText: 'new info text',
+        closeTime: 3,
+        infoIconSrc: 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg'
+    })">打开 toast</button>
     <mip-toast
       id="demo"
-      info-text="默认提示框"
-      station="center"
-      auto-close="false"
+      info-icon-src="https://www.mipengine.org/static/img/sample_mip_logo.png"
+      info-text="默认提示框文字Top+图片"
+      station="top"
+      close-time="1"
     >
     </mip-toast>
   </div>

--- a/components/mip-toast/mip-toast.js
+++ b/components/mip-toast/mip-toast.js
@@ -7,7 +7,8 @@ import './mip-toast.less'
 
 /* global MIP */
 
-const {CustomElement} = MIP
+const {CustomElement, util} = MIP
+const {parse} = util
 
 export default class MIPToast extends CustomElement {
   constructor (element) {
@@ -18,21 +19,25 @@ export default class MIPToast extends CustomElement {
     this.isBlock = false
     this.hasPic = false
     this.showToastText = ''
-    this.showTime = 2500
     this.handleShow = this.handleShow.bind(this)
+    this.handleShowToast = this.handleShowToast.bind(this)
     this.handleHide = this.handleHide.bind(this)
   }
 
   build () {
     this.render()
+    // deprecated
     this.addEventAction('show', this.handleShow)
+
+    this.addEventAction('showToast', this.handleShowToast)
     this.addEventAction('hidden', this.handleHide)
   }
 
-  update () {
-    const {closeTime, infoIconSrc} = this.props
+  update (config) {
+    const closeTime = (config && config.closeTime) || this.props.closeTime
+    const infoIconSrc = (config && config.infoIconSrc) || this.props.infoIconSrc
 
-    this.showTime = closeTime * 1000
+    const showTime = closeTime * 1000
 
     if (!infoIconSrc) {
       this.show = false
@@ -42,10 +47,10 @@ export default class MIPToast extends CustomElement {
     }
     setTimeout(() => {
       this.close = false
-      this.render()
-    }, this.showTime)
+      this.render(config)
+    }, showTime)
 
-    this.render()
+    this.render(config)
   }
 
   handleShow (info) {
@@ -59,13 +64,27 @@ export default class MIPToast extends CustomElement {
     this.update()
   }
 
+  handleShowToast (e, str) {
+    this.close = true
+    let config = {}
+    let infoText = ''
+    if (str) {
+      config = parse(str, 'ObjectLiteral')()
+      infoText = config && config.infoText
+    }
+    this.showToastText = infoText || this.props.infoText
+    this.update(config)
+  }
+
   handleHide () {
     this.close = false
     this.render()
   }
 
-  render () {
-    const {station, infoIconSrc} = this.props
+  render (config) {
+    const station = (config && config.station) || this.props.station
+    const infoIconSrc = (config && config.infoIconSrc) || this.props.infoIconSrc
+
     const wrapper = document.createElement('div')
     const fixed = document.createElement('mip-fixed')
     const toastWrapper = document.createElement('div')


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#671 
#716 

**1、升级点** （清晰准确的描述升级的功能点）

- mip-toast 增加 showToast 方法，参数支持传入字段 infoText、infoIconSrc、closeTime、station
- 修复 mip-sticky-ad 切换页面时新页面底部存在空白区域的问题

**2、影响范围** （描述该需求上线会影响什么功能）
修复 mip-toast 传入参数无效的问题
修复 mip-sticky-ad 切换页面问题

**3、自测 checklist**

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百



